### PR TITLE
fix: ✨ [v4] track info thumbnail not handled properly.

### DIFF
--- a/build/structures/Track.js
+++ b/build/structures/Track.js
@@ -22,6 +22,8 @@ class Track {
 
             if (data.info.thumbnail) {
                 this.info.thumbnail = data.info.thumbnail
+            } else if (data.info.artworkUrl) {
+                this.info.thumbnail = data.info.artworkUrl
             } else {
                 this.info.thumbnail = getImageUrl(this.info)
             }


### PR DESCRIPTION
Added a condition to get the thumbnail from the "artworkUrl" property of Lavalink's raw data when it exists.