### PR TITLE
refactor: collections/maps

### DIFF
--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from "events";
-import { Collection } from "@discordjs/collection";
 
 export declare class Track {
     constructor(data: any, requester: any, node: Node);
@@ -205,8 +204,8 @@ export declare class Riffy extends EventEmitter {
     }, options: RiffyOptions);
     public client: any;
     public nodes: Array<LavalinkNode>;
-    public nodeMap: Collection<k, Node>;
-    public players: Collection<k, Player>;
+    public nodeMap: Map<k, Node>;
+    public players: Map<k, Player>;
     public options: RiffyOptions;
     public clientId: String;
     public initiated: Boolean;

--- a/build/structures/Node.js
+++ b/build/structures/Node.js
@@ -209,8 +209,11 @@ class Node {
     destroy() {
         if (!this.connected) return;
 
-        const player = this.riffy.players.filter((player) => player.node === this);
-        if (player.size) player.forEach((player) => player.destroy());
+        this.riffy.players.forEach((player) => {
+          if (!player.node) return;
+
+          player.destroy()
+        });
 
         if (this.ws) this.ws.close(1000, "destroy");
         this.ws.removeAllListeners();

--- a/build/structures/Riffy.js
+++ b/build/structures/Riffy.js
@@ -1,9 +1,7 @@
 const { EventEmitter } = require("events");
 const { Node } = require("./Node");
-const { Plugin } = require("./Plugins");
 const { Player } = require("./Player");
 const { Track } = require("./Track");
-const { Collection } = require("@discordjs/collection");
 
 const versions = ["v3", "v4"];
 
@@ -16,8 +14,8 @@ class Riffy extends EventEmitter {
 
         this.client = client;
         this.nodes = nodes;
-        this.nodeMap = new Collection();
-        this.players = new Collection();
+        this.nodeMap = new Map();
+        this.players = new Map();
         this.options = options;
         this.clientId = null;
         this.initiated = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,9 @@
       "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
-        "@discordjs/collection": "^2.0.0",
         "jsdom": "^23.0.1",
         "undici": "^6.2.1",
         "ws": "^8.16.0"
-      }
-    },
-    "node_modules/@discordjs/collection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
-      "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w==",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@fastify/busboy": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "build"
   ],
   "dependencies": {
-    "@discordjs/collection": "^2.0.0",
     "jsdom": "^23.0.1",
     "undici": "^6.2.1",
     "ws": "^8.16.0"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR replaces the discord.js collection instances with Node.js/V8 `Map` instances. This allows to remove the `@discordjs/collections` dependency, and use the native solution for JavaScript.

**Status and versioning classification:**

This shouldn't affect external usage in any way. The version is not bumped in this PR.
