### PR TITLE
CI: add continuous (PREVIEW) releases

### DIFF
--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -13,6 +13,11 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
+      - name: evaluate checks
+        run:  echo "Is Approved ${{ github.event.review.state == 'APPROVED' }}"
+            | echo "Is Labeled(DO NOT PREVIEW RELEASE) ${{ contains(github.event.pull_request.labels.name, 'DO NOT PREVIEW RELEASE') }}"
+            | echo "Is Labeled(Bypass check - PREVIEW RELEASE) ${{ contains(github.event.pull_request.labels.name, 'Bypass check - PREVIEW RELEASE') }}"
+            | echo "Is Labeled(PR Manual CI RUN - ${{ github.event.pull_request.labels.name }}) ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.name, 'PR Manual CI RUN') }}"
   approved:
     if: github.event.review.state == 'APPROVED' && !contains(github.event.pull_request.labels.name, 'DO NOT PREVIEW RELEASE') || contains(github.event.pull_request.labels.name, 'Bypass check - PREVIEW RELEASE') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.name, 'PR Manual CI RUN'))
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -3,21 +3,9 @@ on:
   pull_request_review:
     types: [submitted]
   pull_request: 
-    types: [labeled]
+    types: [labeled, synchronize]
 
 jobs:
-  debug: 
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-      - name: evaluate checks
-        run:  echo "Is Approved ${{ github.event.review.state == 'APPROVED' }}"
-            | echo "Is Labeled(DO NOT PREVIEW RELEASE) ${{ contains(github.event.pull_request.labels.*.name, 'DO NOT PREVIEW RELEASE') }}"
-            | echo "Is Labeled(Bypass check - PREVIEW RELEASE) ${{ contains(github.event.pull_request.labels.*.name, 'Bypass check - PREVIEW RELEASE') }}"
-            | echo "Is Labeled(PR Manual CI RUN - ${{ github.event.pull_request.labels.*.name }}) ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'PR Manual CI RUN') }}"
   approved:
     if: github.event.review.state == 'APPROVED' && !contains(github.event.pull_request.labels.*.name, 'DO NOT PREVIEW RELEASE') || contains(github.event.pull_request.labels.*.name, 'Bypass check - PREVIEW RELEASE') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'PR Manual CI RUN'))
     runs-on: ubuntu-latest
@@ -39,6 +27,7 @@ jobs:
 
       - name: Remove Manual PR Run label
         if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'PR Manual CI RUN')
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
+        run: gh pr edit $PR --remove-label $labels
+        env:
+          PR: ${{ github.event.pull_request.number }}
           labels: PR Manual CI RUN

--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Install pkg-pr-new & prebuild, dependencies
         run: npm install pkg-pr-new --save-dev --no-frozen-lockfile
+      
+      - run: ls -la
 
       - run: npx pkg-pr-new publish
 

--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -1,0 +1,32 @@
+name: continuous (Preview) releases
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request: 
+    types: [labeled]
+
+jobs:
+  approved:
+    if: github.event.review.state == 'APPROVED' && !contains(github.event.pull_request.labels.name, 'DO NOT PREVIEW RELEASE') || contains(github.event.pull_request.labels.name, 'Bypass check - PREVIEW RELEASE') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.name, 'PR Manual CI RUN'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install
+
+      - run: npx pkg-pr-new publish
+
+      - name: Remove Manual PR Run label
+        if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.name, 'PR Manual CI RUN')
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: PR Manual CI RUN

--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -38,7 +38,7 @@ jobs:
       - run: npx pkg-pr-new publish
 
       - name: Remove Manual PR Run label
-        if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.name, 'PR Manual CI RUN')
+        if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'PR Manual CI RUN')
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: PR Manual CI RUN

--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -30,4 +30,4 @@ jobs:
         run: gh pr edit $PR --remove-label $labels
         env:
           PR: ${{ github.event.pull_request.number }}
-          labels: PR Manual CI RUN
+          labels: 'PR Manual CI RUN'

--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -5,6 +5,10 @@ on:
   pull_request: 
     types: [labeled, synchronize]
 
+permissions: 
+  pull-requests: write
+
+
 jobs:
   approved:
     if: github.event.review.state == 'APPROVED' && !contains(github.event.pull_request.labels.*.name, 'DO NOT PREVIEW RELEASE') || contains(github.event.pull_request.labels.*.name, 'Bypass check - PREVIEW RELEASE') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'PR Manual CI RUN'))

--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -1,9 +1,25 @@
 name: continuous (Preview) releases
+# avoids paths like tests folder, .md, and anything that starts with `.`
+# also avoids tags.
 on:
   pull_request_review:
     types: [submitted]
   pull_request: 
     types: [labeled, synchronize]
+    paths: 
+      - 'build/**'
+      - '!tests/**'
+      - '!*.md'
+      - '!.*'
+  push: 
+    paths:
+    - 'build/**'
+    - '!tests/**'
+    - '!*.md'
+    - '!.*'
+    branches: [main]
+    tags:
+      - "!**"
 
 permissions: 
   pull-requests: write
@@ -11,7 +27,8 @@ permissions:
 
 jobs:
   approved:
-    if: github.event.review.state == 'APPROVED' && !contains(github.event.pull_request.labels.*.name, 'DO NOT PREVIEW RELEASE') || contains(github.event.pull_request.labels.*.name, 'Bypass check - PREVIEW RELEASE') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'PR Manual CI RUN'))
+    if: github.event.review.state == 'APPROVED' && !contains(github.event.pull_request.labels.*.name, 'DO NOT PREVIEW RELEASE') || contains(github.event.pull_request.labels.*.name, 'Bypass check - PREVIEW RELEASE') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'PR Manual CI RUN')) 
+        || github.event_name == ''
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -2,6 +2,7 @@ name: continuous (Preview) releases
 # avoids paths like tests folder, .md, and anything that starts with `.`
 # also avoids tags.
 on:
+  workflow_dispatch: 
   pull_request_review:
     types: [submitted]
   pull_request: 
@@ -28,7 +29,7 @@ permissions:
 jobs:
   approved:
     if: github.event.review.state == 'APPROVED' && !contains(github.event.pull_request.labels.*.name, 'DO NOT PREVIEW RELEASE') || contains(github.event.pull_request.labels.*.name, 'Bypass check - PREVIEW RELEASE') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'PR Manual CI RUN')) 
-        || github.event_name == 'push'
+        || contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) 
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Remove Manual PR Run label
         if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'PR Manual CI RUN')
-        run: gh pr edit $PR --remove-label $labels
+        run: gh pr edit $PR --remove-label "$labels"
         env:
           PR: ${{ github.event.pull_request.number }}
           labels: 'PR Manual CI RUN'

--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   approved:
     if: github.event.review.state == 'APPROVED' && !contains(github.event.pull_request.labels.*.name, 'DO NOT PREVIEW RELEASE') || contains(github.event.pull_request.labels.*.name, 'Bypass check - PREVIEW RELEASE') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'PR Manual CI RUN')) 
-        || github.event_name == ''
+        || github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -6,6 +6,13 @@ on:
     types: [labeled]
 
 jobs:
+  debug: 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
   approved:
     if: github.event.review.state == 'APPROVED' && !contains(github.event.pull_request.labels.name, 'DO NOT PREVIEW RELEASE') || contains(github.event.pull_request.labels.name, 'Bypass check - PREVIEW RELEASE') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.name, 'PR Manual CI RUN'))
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -31,3 +31,4 @@ jobs:
         env:
           PR: ${{ github.event.pull_request.number }}
           labels: 'PR Manual CI RUN'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -20,8 +20,8 @@ jobs:
           node-version: 20
           cache: "npm"
 
-      - name: Install dependencies
-        run: npm install
+      - name: Install pkg-pr-new & prebuild, dependencies
+        run: npm install pkg-pr-new --save-dev --no-frozen-lockfile
 
       - run: npx pkg-pr-new publish
 

--- a/.github/workflows/continuous-Preview-releases.yml
+++ b/.github/workflows/continuous-Preview-releases.yml
@@ -15,11 +15,11 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - name: evaluate checks
         run:  echo "Is Approved ${{ github.event.review.state == 'APPROVED' }}"
-            | echo "Is Labeled(DO NOT PREVIEW RELEASE) ${{ contains(github.event.pull_request.labels.name, 'DO NOT PREVIEW RELEASE') }}"
-            | echo "Is Labeled(Bypass check - PREVIEW RELEASE) ${{ contains(github.event.pull_request.labels.name, 'Bypass check - PREVIEW RELEASE') }}"
-            | echo "Is Labeled(PR Manual CI RUN - ${{ github.event.pull_request.labels.name }}) ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.name, 'PR Manual CI RUN') }}"
+            | echo "Is Labeled(DO NOT PREVIEW RELEASE) ${{ contains(github.event.pull_request.labels.*.name, 'DO NOT PREVIEW RELEASE') }}"
+            | echo "Is Labeled(Bypass check - PREVIEW RELEASE) ${{ contains(github.event.pull_request.labels.*.name, 'Bypass check - PREVIEW RELEASE') }}"
+            | echo "Is Labeled(PR Manual CI RUN - ${{ github.event.pull_request.labels.*.name }}) ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'PR Manual CI RUN') }}"
   approved:
-    if: github.event.review.state == 'APPROVED' && !contains(github.event.pull_request.labels.name, 'DO NOT PREVIEW RELEASE') || contains(github.event.pull_request.labels.name, 'Bypass check - PREVIEW RELEASE') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.name, 'PR Manual CI RUN'))
+    if: github.event.review.state == 'APPROVED' && !contains(github.event.pull_request.labels.*.name, 'DO NOT PREVIEW RELEASE') || contains(github.event.pull_request.labels.*.name, 'Bypass check - PREVIEW RELEASE') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'PR Manual CI RUN'))
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
# Adds
https://github.com/stackblitz-labs/pkg.pr.new, that Allows **continuous (PREVIEW) releases** for PR (that's what we're using it for) , 

The condition is a combination of three parts, connected by logical OR operators (`||`):

1. `github.event.review.state == 'APPROVED' && !contains(github.event.pull_request.labels.name, 'DO NOT PREVIEW RELEASE')`
	* Check if the review state is 'APPROVED' and the pull request does not have a label named 'DO NOT PREVIEW RELEASE'.
2. `contains(github.event.pull_request.labels.name, 'Bypass check - PREVIEW RELEASE')`
	* Check if the pull request has a label named 'Bypass check - PREVIEW RELEASE'.
3. `(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.name, 'PR Manual CI RUN'))`
	* Check if the event is a pull request and the pull request has a label named 'PR Manual CI RUN'.

If any of these conditions are true, the overall condition is true.

Code Explanation by AI!