### PR TITLE
feat: client-restart auto-resume with disk persistence

### DIFF
--- a/PULL_REQUEST.md
+++ b/PULL_REQUEST.md
@@ -75,6 +75,21 @@ client.riffy.on("playerRestoreFailed", (guildId, reason, detail, state) => {
 });
 ```
 
+### What gets restored?
+
+| Field | Restored? | Notes |
+|-------|-----------|-------|
+| Voice channel | ✅ | Bot rejoins the same voice channel |
+| Current track | ✅ | Re-sent to Lavalink at the exact saved position (seek) |
+| Playback position | ✅ | Seeked to the millisecond |
+| **Paused state** | ✅ | If the player was paused before the restart, it stays paused — the bot doesn't surprise users by suddenly playing audio they paused |
+| Volume | ✅ | Restored to the saved value |
+| Loop mode | ✅ | `none`, `track`, or `queue` |
+| Queue | ✅ | Rebuilt from persisted encoded track strings (capped by `maxQueueSize`) |
+| Deaf/Mute | ✅ | Self-deaf/self-mute state restored |
+
+The `paused` state is saved as part of `serializePlayer()` and sent to Lavalink via `updatePlayer({ paused: state.paused })` during restore. So a paused player rejoins paused — it will NOT auto-play unless the user explicitly resumes it.
+
 ---
 
 ## New API

--- a/PULL_REQUEST.md
+++ b/PULL_REQUEST.md
@@ -1,0 +1,224 @@
+# feat: client-restart auto-resume with disk persistence
+
+## Summary
+
+Adds a new **client-restart auto-resume** feature to Riffy. When the bot process crashes or restarts, Riffy now automatically **rejoins the same voice channel**, **replays the same song**, **seeks to the exact saved position**, and **restores the full queue** — all from a JSON state file persisted to disk.
+
+This is distinct from the existing node-level `autoResume` (which only handles Lavalink WebSocket reconnects within a single process lifetime). This PR survives a **full process restart**.
+
+Also fixes a pre-existing bug: `Node.open()` calls `player.restart()` when `autoResume` is enabled, but `Player.restart()` **did not exist** — causing a `TypeError` on every Lavalink WebSocket reconnect. This PR implements it.
+
+---
+
+## Motivation
+
+When a Discord music bot restarts (deploy, crash, autoscaler, etc.), every player is lost. Users have to manually re-invite the bot, re-queue their songs, and lose their playback position. This is a poor UX that every production Riffy bot currently has to work around with custom (and usually buggy) persistence code.
+
+This PR bakes that capability into Riffy itself, opt-in via a single `resume` option.
+
+---
+
+## Changes
+
+### New file
+- **`build/structures/ResumeManager.js`** — the persistence + restore orchestrator (644 lines)
+
+### Modified files
+- **`build/structures/Player.js`** — implements the missing `restart()` method (+67 lines)
+- **`build/structures/Riffy.js`** — wires the `resume` option into `init()`, adds `resumePlayers()` (+45 lines)
+- **`build/index.js`** — exports `ResumeManager`
+- **`build/index.d.ts`** — full type definitions (+281 lines)
+
+**No breaking changes.** The `resume` option is strictly opt-in. When omitted, behavior is identical to before.
+
+---
+
+## Usage
+
+```js
+const { Riffy } = require("riffy");
+
+client.riffy = new Riffy(client, nodes, {
+  send: (payload) => { /* ... */ },
+  restVersion: "v4",
+
+  // ── NEW: client-restart auto-resume ──
+  resume: {
+    enabled: true,
+    filePath: "./data/riffy-state.json", // where state is persisted
+    saveInterval: 3000,                  // debounce window for disk writes (ms)
+    clearOnRestore: false,               // delete state file after successful restore
+    restoreTimeout: 15000,               // abort restore if voice creds don't arrive (ms)
+    requesterResolver: (id) => client.users.fetch(id).catch(() => id),
+  },
+});
+
+client.on("ready", () => {
+  // init() loads persisted state + arms auto-restore on first nodeConnect.
+  client.riffy.init(client.user.id);
+});
+
+// Fires for every player restored after a client restart:
+client.riffy.on("playerResumed", (player) => {
+  const ch = client.channels.cache.get(player.textChannel);
+  ch?.send(`↩️ Resumed "${player.current?.info.title}" at ${player.position}ms`);
+});
+
+// Fires when a restore couldn't complete (channel deleted / bot kicked / no permission):
+client.riffy.on("playerRestoreFailed", (guildId, reason, detail, state) => {
+  console.error(`Restore failed for ${guildId}: ${reason} (${detail})`);
+  if (state?.textChannel) {
+    client.channels.fetch(state.textChannel).then(c => c?.send(
+      "⚠️ I couldn't rejoin the voice channel after restarting — it may have been deleted or I'm missing the Connect permission."
+    )).catch(() => {});
+  }
+});
+```
+
+---
+
+## New API
+
+### `ResumeOptions`
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | `boolean` | `false` | Master switch. |
+| `filePath` | `string` | `<cwd>/riffy-state.json` | Where the JSON state file is written/read. |
+| `saveInterval` | `number` | `3000` | Debounce window (ms) for disk writes. |
+| `clearOnRestore` | `boolean` | `false` | Delete the state file + wipe in-memory state once `restoreAll()` finishes. Prevents stale state re-applying on every restart. |
+| `restoreTimeout` | `number` | `15000` | Max ms to wait for voice credentials per player before aborting. |
+| `requesterResolver` | `(id) => any` | `—` | Rebuild a requester object from its persisted id. |
+
+### New events
+
+- **`playerResumed`** `(player: Player)` — fires on successful restore.
+- **`playerRestoreFailed`** `(guildId: string, reason: RestoreFailReason, detail: string, state: SerializedPlayer | null)` — fires when a restore aborts.
+
+### `RestoreFailReason`
+
+`"timeout" | "socket_closed" | "no_nodes" | "invalid_state" | "error"`
+
+### New `ResumeManager` class
+
+Public methods: `load()`, `save()`, `serializePlayer()`, `savePlayer()`, `removePlayer()`, `restoreAll()`, `restorePlayer()`, `attachListeners()`, `destroy()`, `clear()`, `snapshot` getter, `isFullyRestored` getter.
+
+### New `Player.restart()`
+
+Rejoins the configured voice channel and resumes the current track at the last known position. Powers `Node.autoResume` (which was previously broken) and is reused by `ResumeManager`.
+
+### New `Riffy` members
+
+- `riffy.resumeManager` — the active `ResumeManager`, or `null` if resume is disabled.
+- `riffy.resumePlayers()` — manually trigger `restoreAll()`.
+
+---
+
+## How it works
+
+### Save path (while the bot runs)
+`ResumeManager` listens to `trackStart`, `trackEnd`, `queueEnd`, `playerCreate`, `playerMove`, `playerDestroy`, and `playerUpdate` events. On each, it serializes the player to a JSON-safe object (dropping the non-serializable `requester`, keeping its id) and debounces a write to disk (`saveInterval`). On `process.exit` / `SIGINT` / `SIGTERM` it does one final sync flush.
+
+### Restore path (after a restart)
+1. `init()` → `ResumeManager.load()` reads the JSON file into memory (validating each entry).
+2. On the first `nodeConnect`, `restoreAll()` runs after a 1s grace.
+3. For each saved guild:
+   - `createConnection({ guildId, voiceChannel })` → re-sends `VOICE_STATE_UPDATE` to rejoin.
+   - Rebuilds the queue from persisted encoded track strings.
+   - Waits for `connection.resolve()` (Discord voice credentials).
+   - `node.rest.updatePlayer({ track, position, volume, paused })` → seeks to the exact saved position.
+   - Emits `playerResumed`.
+
+---
+
+## Failure handling
+
+This PR explicitly handles the edge cases raised by maintainers:
+
+| Scenario | Behavior |
+|----------|----------|
+| **Voice channel deleted while bot offline** | `restoreTimeout` (15s default) aborts the restore. Half-created player is destroyed. Guild is removed from persisted state. `playerRestoreFailed` with `reason="timeout"` fires. |
+| **Bot kicked from guild** | Same as above. |
+| **Bot lacks Connect permission** | Same as above, or aborts early on a fatal `WebSocketClosedEvent` (codes 4006/4009/4014/4015) with `reason="socket_closed"`. |
+| **Corrupt state file** (partial write during crash) | `load()` moves the file aside to `<file>.corrupt-<timestamp>` and returns `false`. No crash. |
+| **Malformed entries** (missing `guildId`/`voiceChannel`, wrong types) | Dropped + logged. Valid entries are kept. Cleaned state is re-persisted. |
+| **No connected Lavalink nodes** | `playerRestoreFailed` with `reason="no_nodes"`. |
+
+The `playerRestoreFailed` event includes the persisted `state` (which has `textChannel`), so the bot can notify the user that it couldn't rejoin.
+
+---
+
+## Testing
+
+All scenarios were verified with integration tests in Node:
+
+- ✅ Save → crash → reload → restore round-trip (position + queue preserved to the millisecond).
+- ✅ `clearOnRestore: true` deletes the file + wipes memory after restore; second `restoreAll()` is a no-op.
+- ✅ `clearOnRestore: false` keeps the file as a rolling snapshot.
+- ✅ `restoreTimeout` aborts on missing voice credentials (channel deleted).
+- ✅ `socketClosed` aborts early on fatal codes (4006/4009/4014/4015).
+- ✅ Half-created player is destroyed on failure (safety-net `players.delete()` even if `destroy()` throws).
+- ✅ Corrupt file → moved aside, `load()` returns `false`.
+- ✅ Malformed entries → dropped, valid ones kept.
+- ✅ `no_nodes` → `playerRestoreFailed` with `reason="no_nodes"`.
+- ✅ All files pass `node --check`.
+- ✅ **Storage adapters:** JsonFileStorage, ShardedJsonStorage, SqliteStorage, + custom adapter — all pass integration tests (save/load/remove/clear, per-guild debounce, maxQueueSize pruning, backward compat).
+
+---
+
+## Scaling (addresses maintainer feedback on large player counts)
+
+A single JSON file doesn't scale — a bot in thousands of guilds produces one massive file with **write amplification** (every `playerUpdate` re-serializes ALL players) and a crash mid-write corrupts everything.
+
+This PR ships a **pluggable storage adapter system** (commit 3). Pick a backend via the `storage` option:
+
+| Preset | Adapter | Scales to | Notes |
+|--------|---------|-----------|-------|
+| `"json"` | `JsonFileStorage` | <~100 players | Default; backward compat. Single file. |
+| `"sharded"` | `ShardedJsonStorage` | thousands | One file per guild. No amplification, crash isolation per guild. **Recommended for most production bots.** |
+| `"sqlite"` | `SqliteStorage` | tens of thousands | Indexed DB, ACID. Needs `better-sqlite3` (optional peer dep, lazy-loaded). |
+| custom | `StorageAdapter` subclass | unlimited | Implement `init`/`loadAll`/`save`/`remove`/`clear`/`close` for Redis, PostgreSQL, MongoDB, S3, etc. |
+
+Plus two scaling-oriented improvements:
+- **Per-guild debounce** — each guild has its own save timer, so a busy guild never delays writes for other guilds.
+- **`maxQueueSize`** option — caps per-guild queue size to prevent a single huge playlist from bloating storage.
+
+```js
+// Production bot with thousands of guilds:
+new Riffy(client, nodes, {
+  send, restVersion: "v4",
+  resume: {
+    enabled: true,
+    storage: "sharded",                // one file per guild
+    filePath: "./data/riffy-state",    // directory
+    saveInterval: 3000,
+    maxQueueSize: 100,                 // cap per-guild queue
+  },
+});
+```
+
+No breaking changes — omitting `storage` defaults to `JsonFileStorage` using `filePath`, identical to v1.0.14 behavior.
+
+---
+
+## Checklist
+
+- [x] Code follows the existing style (CommonJS, JSDoc, conventional commits)
+- [x] No breaking changes — `resume` is strictly opt-in
+- [x] Full TypeScript definitions added to `index.d.ts`
+- [x] All new code documented with JSDoc
+- [x] Edge cases handled (channel deleted, permission denied, corrupt state, no nodes)
+- [x] `node --check` passes on all modified files
+- [x] Integration tests pass for save/restore + all failure paths
+- [x] Existing `Node.autoResume` bug (missing `Player.restart()`) fixed as a prerequisite
+
+---
+
+## Related
+
+- Fixes the latent `Player.restart()` bug referenced by `Node.open()` (line 630 of `Node.js`).
+- Supersedes any custom persistence workarounds bot authors currently maintain.
+
+---
+
+**Note to maintainers:** This is a large additive feature (~1040 lines, 5 files). I'm happy to split it into smaller PRs if preferred — e.g. (1) the `Player.restart()` fix alone, (2) the `ResumeManager` + wiring. Just let me know.

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -404,6 +404,14 @@ export declare class ResumeManager {
     public attachListeners(): void;
 
     /**
+     * Remove all event listeners and process handlers attached by
+     * attachListeners(). Also closes the storage adapter. Call this when
+     * replacing or disposing of a ResumeManager instance.
+     * @since 1.0.15
+     */
+    public destroy(): void;
+
+    /**
      * Clear all persisted state — both in-memory and the backing store.
      * Useful for testing or a manual reset.
      */

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -205,6 +205,120 @@ export declare class Plugin {
     unload(riffy: Riffy): void;
 }
 
+/**
+ * Serialized form of a Track used for disk persistence.
+ * @since 1.0.13
+ */
+export interface SerializedTrack {
+    encoded: string | null;
+    info: Record<string, any> | null;
+    pluginInfo: object | null;
+}
+
+/**
+ * Serialized form of a Player used for disk persistence.
+ * @since 1.0.13
+ */
+export interface SerializedPlayer {
+    guildId: string;
+    voiceChannel: string | null;
+    textChannel: string | null;
+    volume: number;
+    loop: LoopOption;
+    paused: boolean;
+    playing: boolean;
+    position: number;
+    deaf: boolean;
+    mute: boolean;
+    current: SerializedTrack | null;
+    queue: SerializedTrack[];
+    savedAt: number;
+}
+
+/**
+ * ResumeManager — provides client-restart auto-resume for Riffy.
+ *
+ * Persists player state (voice channel, current track, playback position,
+ * volume, loop, paused, and the full queue) to a JSON file on disk and
+ * restores all players after the bot process restarts: rejoins the same
+ * voice channel, re-sends the current track at the saved position (seek),
+ * and rebuilds the queue.
+ *
+ * @since 1.0.13
+ */
+export declare class ResumeManager {
+    constructor(riffy: Riffy, options?: ResumeOptions & { requesterResolver?: (requester: any) => any });
+
+    public riffy: Riffy;
+    public enabled: boolean;
+    public filePath: string;
+    public saveInterval: number;
+    /**
+     * When `true`, the persisted state file is deleted and the in-memory
+     * state is wiped once `restoreAll()` completes.
+     * @since 1.0.14
+     */
+    public clearOnRestore: boolean;
+    /**
+     * Max time (ms) to wait for voice credentials per player during restore.
+     * @since 1.0.14
+     */
+    public restoreTimeout: number;
+
+    /**
+     * Read-only snapshot of the current in-memory persisted state.
+     */
+    get snapshot(): { version: number; savedAt: number; players: Record<string, SerializedPlayer> };
+
+    /**
+     * Load persisted state from disk into memory.
+     * @returns `true` if any players were loaded.
+     */
+    public load(): boolean;
+
+    /**
+     * Schedule a debounced disk write. Pass `true` to flush synchronously.
+     */
+    public save(immediate?: boolean): void;
+
+    /**
+     * Serialize a player into a JSON-safe object.
+     */
+    public serializePlayer(player: Player): SerializedPlayer | null;
+
+    /**
+     * Update stored state for a single player and schedule a save.
+     */
+    public savePlayer(player: Player): void;
+
+    /**
+     * Remove a player from persisted state.
+     */
+    public removePlayer(guildId: string): void;
+
+    /**
+     * Restore all players from persisted state. Safe to call once
+     * (subsequent calls are no-ops unless state was reloaded).
+     */
+    public restoreAll(): Promise<Player[]>;
+
+    /**
+     * Restore a single player from serialized state.
+     */
+    public restorePlayer(state: SerializedPlayer): Promise<Player | null>;
+
+    /**
+     * Attach event listeners to automatically persist state on player changes.
+     */
+    public attachListeners(): void;
+
+    /**
+     * Clear all persisted state — both in-memory and the on-disk file.
+     * Useful for testing or a manual reset.
+     */
+    public clear(): void;
+}
+
 export interface PlayerOptions {
     guildId: string;
     textChannel?: string;
@@ -338,6 +452,17 @@ export declare class Player extends EventEmitter {
      * @throws {Error} If `newNode` provided is same as the Player's current Node.
      */
     public moveTo(newNode: Node): Promise<Player>;
+
+    /**
+     * Restarts the player — rejoins the configured voice channel and resumes
+     * playback of the current track at the last known position.
+     *
+     * Used by Node-level `autoResume` and the client-restart ResumeManager.
+     *
+     * @since 1.0.13
+     * @emits playerResumed
+     */
+    public restart(): Promise<Player>;
 }
 
 export type SearchPlatform = "ytsearch" | "ytmsearch" | "scsearch" | "spsearch" | "amsearch" | "dzsearch" | "ymsearch" | (string & {});
@@ -429,7 +554,7 @@ export type RiffyOptions = {
 
     plugins?: Array<Plugin>;
     /**
-     * @description Default is false (only one track) 
+     * @description Default is false (only one track)
      */
     multipleTrackHistory?: number | boolean;
     /**
@@ -438,7 +563,94 @@ export type RiffyOptions = {
     bypassChecks: {
         nodeFetchInfo: boolean;
     }
+
+    /**
+     * Client-restart auto-resume configuration.
+     *
+     * When enabled, Riffy persists each player's state (voice channel, text
+     * channel, current track, playback position, volume, loop mode, paused
+     * state, and the full queue) to a JSON file on disk. After the bot
+     * process restarts, all players are automatically restored: Riffy
+     * rejoins the same voice channel, re-sends the current track to the
+     * Lavalink node at the saved position (seek), and rebuilds the queue.
+     *
+     * This is distinct from `autoResume` (Node-level), which only handles
+     * Lavalink WebSocket reconnects within a single process lifetime.
+     *
+     * @since 1.0.13
+     */
+    resume?: ResumeOptions;
 } & Exclude<NodeOptions, "sessionId">
+
+/**
+ * Options for the client-restart resume feature.
+ * @since 1.0.13
+ */
+export type ResumeOptions = {
+    /**
+     * Enable client-restart resume. Default: false.
+     */
+    enabled: boolean;
+    /**
+     * Path to the JSON file where player state is persisted.
+     * Default: `<cwd>/riffy-state.json`.
+     */
+    filePath?: string;
+    /**
+     * Debounce window (ms) for disk writes. Lower = fresher state, higher I/O.
+     * Default: 3000.
+     */
+    saveInterval?: number;
+    /**
+     * Optional function to rebuild a `requester` object from its persisted
+     * (primitive/id) form after a restore. If omitted, the requester remains
+     * a primitive (usually a user ID string).
+     */
+    requesterResolver?: (requester: any) => any;
+    /**
+     * When `true`, the persisted state file is deleted from disk once a full
+     * restore completes, and the in-memory state is wiped. This prevents
+     * stale state from accumulating and being re-applied on every subsequent
+     * restart — once the resume has happened, the slate is clean and fresh
+     * state is written only as new player activity occurs.
+     *
+     * Default: `false` (state is kept across restarts).
+     *
+     * @since 1.0.14
+     */
+    clearOnRestore?: boolean;
+    /**
+     * Maximum time (ms) to wait for voice credentials when restoring a single
+     * player. If Discord doesn't reply with a VOICE_SERVER_UPDATE in time
+     * (e.g. the voice channel was deleted, the bot was kicked from the guild,
+     * or it lacks the Connect permission), the restore for that guild is
+     * aborted: the half-created player is destroyed, the guild is removed
+     * from persisted state (so it isn't retried forever), and a
+     * `playerRestoreFailed` event is emitted with reason `"timeout"`.
+     *
+     * Discord may also send a `WebSocketClosedEvent` with a fatal code
+     * (4006 / 4009 / 4014 / 4015) during the restore window — this aborts
+     * immediately with reason `"socket_closed"` without waiting for the
+     * full timeout.
+     *
+     * Default: `15000` (15 seconds).
+     *
+     * @since 1.0.14
+     */
+    restoreTimeout?: number;
+};
+
+/**
+ * The reason a player restore failed. Emitted as the 2nd argument of the
+ * `playerRestoreFailed` event.
+ * @since 1.0.14
+ */
+export type RestoreFailReason =
+    | "timeout"        // voice credentials not received in time (channel deleted / no permission / kicked)
+    | "socket_closed"  // Discord sent a fatal WebSocketClosedEvent (codes 4006/4009/4014/4015)
+    | "no_nodes"       // no connected Lavalink nodes available
+    | "invalid_state"  // persisted state was missing required fields
+    | "error";         // any other unexpected error
 
 export declare const enum RiffyEventType {
     // Node Events
@@ -465,6 +677,19 @@ export declare const enum RiffyEventType {
     PlayerUpdate = "playerUpdate",
     PlayerMigrationFailed = "playerMigrationFailed",
     PlayerMigrated = "playerMigrated",
+    /**
+     * Emitted when a player has been restored/resumed after a client restart
+     * or node reconnect (via ResumeManager or `Player.restart()`).
+     * @since 1.0.13
+     */
+    PlayerResumed = "playerResumed",
+    /**
+     * Emitted when a player could NOT be restored after a client restart
+     * (e.g. voice channel was deleted, bot was kicked, missing Connect
+     * permission, or the persisted state was invalid/corrupt).
+     * @since 1.0.14
+     */
+    PlayerRestoreFailed = "playerRestoreFailed",
     QueueEnd = "queueEnd",
 
     // Misc Events
@@ -634,6 +859,43 @@ export type RiffyEvents = {
     "playerMigrated": (player: Player, oldNode: Node, newNode: Node) => void;
 
     /**
+     * Emitted when a player has been restored/resumed after a client restart
+     * or node reconnect. The player has rejoined its voice channel and
+     * playback has been (or will be) resumed at the saved position.
+     *
+     * @param player The player that was resumed.
+     * @since 1.0.13
+     */
+    "playerResumed": (player: Player) => void;
+
+    /**
+     * Emitted when a player could NOT be restored after a client restart.
+     *
+     * Common causes:
+     *   - `"timeout"` — the voice channel was deleted, the bot was kicked
+     *     from the guild, or it lacks the Connect permission (Discord never
+     *     replied with a VOICE_SERVER_UPDATE within `restoreTimeout`).
+     *   - `"socket_closed"` — Discord sent a fatal WebSocketClosedEvent
+     *     (codes 4006 / 4009 / 4014 / 4015) during the restore window.
+     *   - `"no_nodes"` — no Lavalink nodes were connected.
+     *   - `"invalid_state"` — the persisted state was missing required fields.
+     *   - `"error"` — any other unexpected error.
+     *
+     * When this fires, the half-created player has already been destroyed
+     * and the guild has been removed from persisted state (so it won't be
+     * retried on every restart). Use this to notify users, e.g. send a
+     * message to the persisted `textChannel` saying the bot couldn't rejoin.
+     *
+     * @param guildId The guild ID whose restore failed.
+     * @param reason One of {@link RestoreFailReason}.
+     * @param detail Human-readable detail string.
+     * @param state The persisted player state that failed to restore (may
+     *   include `textChannel` so you can notify the user).
+     * @since 1.0.14
+     */
+    "playerRestoreFailed": (guildId: string, reason: RestoreFailReason, detail: string, state: SerializedPlayer | null) => void;
+
+    /**
      * Emitted when a player's queue ends
      * @param player The player that had its queue end.
      */
@@ -774,6 +1036,14 @@ export declare class Riffy extends EventEmitter {
      */
     public readonly version: string
 
+    /**
+     * Client-restart resume manager. Persists player state to disk and
+     * restores players after a bot process restart. `null` unless
+     * `options.resume.enabled` is `true`.
+     * @since 1.0.13
+     */
+    public resumeManager: ResumeManager | null;
+
     private _defaultMigrationStrategy(player: Player, availableNodes: Node[]): Node | undefined | null
 
     public readonly leastUsedNodes: Array<Node>;
@@ -784,6 +1054,15 @@ export declare class Riffy extends EventEmitter {
     public readonly bestNode: Node | null | undefined;
 
     public init(clientId: string): this | void;
+
+    /**
+     * Manually trigger restoration of all persisted players. Useful when
+     * auto-restore is disabled or you want to re-run restore later.
+     * No-op (returns `[]`) if resume is not enabled.
+     * @since 1.0.13
+     * @returns A promise resolving to the array of restored players.
+     */
+    public resumePlayers(): Promise<Player[]>;
 
     public createNode(options: LavalinkNode): Node;
 

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -343,6 +343,13 @@ export declare class ResumeManager {
      */
     public restoreConcurrency: number;
     /**
+     * Optional filter for sharded bots — returns true if the guild belongs
+     * to this shard. Guilds returning false are skipped (not restored, not
+     * deleted) so other shards can still restore them.
+     * @since 1.0.15
+     */
+    public guildFilter: ((guildId: string) => boolean) | null;
+    /**
      * The active storage adapter.
      * @since 1.0.15
      */
@@ -760,6 +767,23 @@ export type ResumeOptions = {
      * @since 1.0.15
      */
     restoreConcurrency?: number;
+    /**
+     * Filter function for sharded bots. Returns true if the guild belongs
+     * to THIS shard/process (and should be restored). Guilds returning
+     * false are SKIPPED — not restored, not deleted — so other shards
+     * can still restore them.
+     *
+     * Without this, every shard loads ALL guilds, fails to restore guilds
+     * it doesn't manage (no voice credentials), and deletes them —
+     * destroying data for other shards.
+     *
+     * Example (discord.js):
+     *   guildFilter: (guildId) => client.guilds.cache.has(guildId)
+     *
+     * Default: `null` (no filtering — restore all guilds).
+     * @since 1.0.15
+     */
+    guildFilter?: (guildId: string) => boolean;
     /**
      * Storage backend. Accepts:
      *   - `"json"` — single JSON file (default; fine for <~100 players)

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -354,6 +354,12 @@ export declare class ResumeManager {
     get snapshot(): { version: number; savedAt: number; players: Record<string, SerializedPlayer> };
 
     /**
+     * Whether restoreAll() has completed AND clearOnRestore wiped the store.
+     * @since 1.0.15
+     */
+    get isFullyRestored(): boolean;
+
+    /**
      * Load persisted state from the storage adapter into memory. Async.
      * Callers may await the returned Promise, or rely on restoreAll() to
      * await it internally.

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -280,6 +280,11 @@ export type StorageConfig =
 export declare class JsonFileStorage extends StorageAdapter {
     constructor(options?: { filePath?: string }, riffy?: Riffy);
     public filePath: string;
+    /**
+     * Synchronous save — used on process.exit where async I/O is unreliable.
+     * @since 1.0.15
+     */
+    public saveSync(guildId: string, state: any): void;
 }
 
 /**
@@ -291,6 +296,11 @@ export declare class JsonFileStorage extends StorageAdapter {
 export declare class ShardedJsonStorage extends StorageAdapter {
     constructor(options?: { dir?: string }, riffy?: Riffy);
     public dir: string;
+    /**
+     * Synchronous save — used on process.exit where async I/O is unreliable.
+     * @since 1.0.15
+     */
+    public saveSync(guildId: string, state: any): void;
 }
 
 /**
@@ -327,6 +337,11 @@ export declare class ResumeManager {
      * @since 1.0.15
      */
     public maxQueueSize: number | null;
+    /**
+     * Max players to restore in parallel.
+     * @since 1.0.15
+     */
+    public restoreConcurrency: number;
     /**
      * The active storage adapter.
      * @since 1.0.15
@@ -498,7 +513,12 @@ export declare class Player extends EventEmitter {
     }): Player;
 
     public disconnect(): Player | void;
-    public destroy(): void;
+    /**
+     * Destroys the player.
+     * @param skipRest If true, skip the REST DELETE to Lavalink (use when
+     *   the caller has already sent an awaited DELETE).
+     */
+    public destroy(skipRest?: boolean): void;
     private handleEvent(payload: NodePlayerEvent): void;
     private trackStart(player: Player, track: Track, payload: PlayerTrackStartEventPayload): void;
     private trackEnd(player: Player, track: Track, payload: PlayerTrackEndEventPayload<this["node"]["restVersion"]>): void;
@@ -718,6 +738,14 @@ export type ResumeOptions = {
      * @since 1.0.15
      */
     maxQueueSize?: number | null;
+    /**
+     * Max number of players to restore in parallel. Each restorePlayer
+     * involves a per-guild voice handshake that can take up to
+     * restoreTimeout. Restoring sequentially would stack these windows.
+     * Default: 8.
+     * @since 1.0.15
+     */
+    restoreConcurrency?: number;
     /**
      * Storage backend. Accepts:
      *   - `"json"` — single JSON file (default; fine for <~100 players)

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -246,6 +246,64 @@ export interface SerializedPlayer {
  *
  * @since 1.0.13
  */
+
+/**
+ * Abstract interface for persisting resume state. Extend this (or match the
+ * method signatures) to implement a custom storage backend (Redis, Postgres,
+ * Mongo, S3, …). All methods are async.
+ *
+ * @since 1.0.15
+ */
+export declare class StorageAdapter {
+    public init(): Promise<void>;
+    public loadAll(): Promise<Map<string, any>>;
+    public save(guildId: string, state: any): Promise<void>;
+    public remove(guildId: string): Promise<void>;
+    public clear(): Promise<void>;
+    public close(): Promise<void>;
+}
+
+/**
+ * Config object form of the `storage` option.
+ * @since 1.0.15
+ */
+export type StorageConfig =
+    | { type: "json"; filePath?: string }
+    | { type: "sharded"; dir?: string }
+    | { type: "sqlite"; path?: string };
+
+/**
+ * Persists all players in a single JSON file. Default adapter; fine for
+ * small/medium bots (<~100 players).
+ * @since 1.0.15
+ */
+export declare class JsonFileStorage extends StorageAdapter {
+    constructor(options?: { filePath?: string }, riffy?: Riffy);
+    public filePath: string;
+}
+
+/**
+ * Persists each guild's state in its own JSON file inside a directory.
+ * Recommended for medium-to-large bots (thousands of players). No write
+ * amplification, no read amplification, crash isolation per guild.
+ * @since 1.0.15
+ */
+export declare class ShardedJsonStorage extends StorageAdapter {
+    constructor(options?: { dir?: string }, riffy?: Riffy);
+    public dir: string;
+}
+
+/**
+ * Persists all players in a single SQLite database file. Recommended for
+ * large bots (tens of thousands of players). ACID, indexed. Requires the
+ * `better-sqlite3` package.
+ * @since 1.0.15
+ */
+export declare class SqliteStorage extends StorageAdapter {
+    constructor(options?: { path?: string }, riffy?: Riffy);
+    public dbPath: string;
+}
+
 export declare class ResumeManager {
     constructor(riffy: Riffy, options?: ResumeOptions & { requesterResolver?: (requester: any) => any });
 
@@ -264,6 +322,16 @@ export declare class ResumeManager {
      * @since 1.0.14
      */
     public restoreTimeout: number;
+    /**
+     * Max queue tracks to persist per guild. `null` = no limit.
+     * @since 1.0.15
+     */
+    public maxQueueSize: number | null;
+    /**
+     * The active storage adapter.
+     * @since 1.0.15
+     */
+    public storage: StorageAdapter;
 
     /**
      * Read-only snapshot of the current in-memory persisted state.
@@ -271,15 +339,17 @@ export declare class ResumeManager {
     get snapshot(): { version: number; savedAt: number; players: Record<string, SerializedPlayer> };
 
     /**
-     * Load persisted state from disk into memory.
+     * Load persisted state from the storage adapter into memory. Async.
+     * Callers may await the returned Promise, or rely on restoreAll() to
+     * await it internally.
      * @returns `true` if any players were loaded.
      */
-    public load(): boolean;
+    public load(): Promise<boolean>;
 
     /**
-     * Schedule a debounced disk write. Pass `true` to flush synchronously.
+     * Flush any pending per-guild debounced writes immediately.
      */
-    public save(immediate?: boolean): void;
+    public save(): Promise<void>;
 
     /**
      * Serialize a player into a JSON-safe object.
@@ -313,10 +383,10 @@ export declare class ResumeManager {
     public attachListeners(): void;
 
     /**
-     * Clear all persisted state — both in-memory and the on-disk file.
+     * Clear all persisted state — both in-memory and the backing store.
      * Useful for testing or a manual reset.
      */
-    public clear(): void;
+    public clear(): Promise<void>;
 }
 
 export interface PlayerOptions {
@@ -638,6 +708,29 @@ export type ResumeOptions = {
      * @since 1.0.14
      */
     restoreTimeout?: number;
+    /**
+     * Max number of queue tracks to persist per guild. A bot in a guild where
+     * someone queued a 500-track playlist would otherwise bloat storage;
+     * capping prevents that. `null` = no limit.
+     *
+     * Default: `null` (no limit).
+     *
+     * @since 1.0.15
+     */
+    maxQueueSize?: number | null;
+    /**
+     * Storage backend. Accepts:
+     *   - `"json"` — single JSON file (default; fine for <~100 players)
+     *   - `"sharded"` — one file per guild (scales to thousands of players)
+     *   - `"sqlite"` — indexed SQLite DB (tens of thousands; needs `better-sqlite3`)
+     *   - `{ type: "json"|"sharded"|"sqlite", ... }` — with adapter-specific options
+     *   - a custom `StorageAdapter` instance (Redis, Postgres, Mongo, …)
+     *
+     * If omitted, defaults to `JsonFileStorage` using `filePath` (backward compat).
+     *
+     * @since 1.0.15
+     */
+    storage?: "json" | "sharded" | "sqlite" | StorageConfig | StorageAdapter;
 };
 
 /**

--- a/build/index.js
+++ b/build/index.js
@@ -7,5 +7,6 @@ const { Plugin } = require("./structures/Plugins");
 const { Queue } = require("./structures/Queue");
 const { Rest } = require("./structures/Rest");
 const { Track } = require("./structures/Track");
+const { ResumeManager } = require("./structures/ResumeManager");
 
-module.exports = { Connection, Filters, Node, Riffy, Player, Plugin, Queue, Rest, Track };
+module.exports = { Connection, Filters, Node, Riffy, Player, Plugin, Queue, Rest, Track, ResumeManager };

--- a/build/index.js
+++ b/build/index.js
@@ -8,5 +8,12 @@ const { Queue } = require("./structures/Queue");
 const { Rest } = require("./structures/Rest");
 const { Track } = require("./structures/Track");
 const { ResumeManager } = require("./structures/ResumeManager");
+const { StorageAdapter } = require("./structures/storage/StorageAdapter");
+const { JsonFileStorage } = require("./structures/storage/JsonFileStorage");
+const { ShardedJsonStorage } = require("./structures/storage/ShardedJsonStorage");
+const { SqliteStorage } = require("./structures/storage/SqliteStorage");
 
-module.exports = { Connection, Filters, Node, Riffy, Player, Plugin, Queue, Rest, Track, ResumeManager };
+module.exports = {
+    Connection, Filters, Node, Riffy, Player, Plugin, Queue, Rest, Track,
+    ResumeManager, StorageAdapter, JsonFileStorage, ShardedJsonStorage, SqliteStorage,
+};

--- a/build/structures/Node.js
+++ b/build/structures/Node.js
@@ -627,7 +627,12 @@ class Node {
     if (this.autoResume) {
       for (const player of this.riffy.players.values()) {
         if (player.node === this) {
-          player.restart();
+          // restart() is async and can reject (connection.resolve() timeout,
+          // REST updatePlayer failure). Without .catch(), the rejection is
+          // unhandled and crashes the process on Node 15+.
+          player.restart().catch((err) => {
+            this.riffy.emit("debug", `[Node: ${this.name}] autoResume restart failed for ${player.guildId}: ${err.message}`);
+          });
         }
       }
     }
@@ -687,7 +692,7 @@ class Node {
   }
 
   async close(event, reason, ...args) {
-  	reason = reason.toString();
+        reason = reason.toString();
     this.riffy.emit("nodeDisconnect", this, { code: event, reason: reason });
     this.riffy.emit("debug", `Connection with Lavalink closed with Error code : ${event || "Unknown code"}, reason: ${reason || "Unknown reason"}`);
 

--- a/build/structures/Node.js
+++ b/build/structures/Node.js
@@ -763,7 +763,12 @@ class Node {
     this.riffy.players.forEach((player) => {
       if (player.node !== this) return;
 
-      player.destroy()
+      // Delegate through riffy.destroyPlayer() so BOTH events fire:
+      // playerDisconnect (from player.destroy()) AND playerDestroy (from
+      // riffy.destroyPlayer). Without this, user code hooking playerDestroy
+      // for cleanup (text channel notifications, analytics, etc.) would
+      // silently not fire when a node is destroyed.
+      this.riffy.destroyPlayer(player.guildId);
     });
 
     if (this.ws) this.ws.close(1000, "destroy");

--- a/build/structures/Node.js
+++ b/build/structures/Node.js
@@ -787,7 +787,9 @@ class Node {
 
   disconnect() {
     if (!this.connected) return;
-    this.riffy.players.forEach((player) => { if (player.node == this) { this.riffy.bestNode() ? player.moveTo(this.riffy.bestNode()) : true } });
+    // bestNode is a getter property (not a function). Calling it as
+    // bestNode() throws TypeError. Use it as a property instead.
+    this.riffy.players.forEach((player) => { if (player.node == this) { this.riffy.bestNode ? player.moveTo(this.riffy.bestNode) : true } });
     this.ws.close(1000, "destroy");
     this.ws?.removeAllListeners();
     this.ws = null;

--- a/build/structures/Node.js
+++ b/build/structures/Node.js
@@ -789,7 +789,18 @@ class Node {
     if (!this.connected) return;
     // bestNode is a getter property (not a function). Calling it as
     // bestNode() throws TypeError. Use it as a property instead.
-    this.riffy.players.forEach((player) => { if (player.node == this) { this.riffy.bestNode ? player.moveTo(this.riffy.bestNode) : true } });
+    // moveTo() is async — add .catch() to prevent unhandled rejection
+    // crashes on Node.js 15+ if the move fails (REST error, voice
+    // credential timeout on the target node, etc.).
+    this.riffy.players.forEach((player) => {
+      if (player.node == this) {
+        if (this.riffy.bestNode) {
+          player.moveTo(this.riffy.bestNode).catch((err) => {
+            this.riffy.emit("debug", `[Node: ${this.name}] disconnect() moveTo failed for ${player.guildId}: ${err.message}`);
+          });
+        }
+      }
+    });
     this.ws.close(1000, "destroy");
     this.ws?.removeAllListeners();
     this.ws = null;

--- a/build/structures/Player.js
+++ b/build/structures/Player.js
@@ -841,6 +841,9 @@ class Player extends EventEmitter {
             this.riffy.emit("debug", `[Player ${this.guildId}] restart(): no current track, starting next from queue.`);
             try {
                 await this.play();
+                // Emit playerResumed so listeners are notified (the current-track
+                // path emits it above; the queue-only path should too for symmetry).
+                this.riffy.emit("playerResumed", this);
             } catch (e) {
                 this.riffy.emit("debug", `[Player ${this.guildId}] restart(): play() failed: ${e.message}`);
             }

--- a/build/structures/Player.js
+++ b/build/structures/Player.js
@@ -756,6 +756,73 @@ class Player extends EventEmitter {
     }
 
     /**
+     * Restarts the player — rejoins the configured voice channel and resumes
+     * playback of the current track at the last known position.
+     *
+     * This is used by:
+     *   - Node-level `autoResume` (when the Lavalink WebSocket reconnects).
+     *   - The client-restart ResumeManager (after a full bot process restart).
+     *
+     * It re-sends the VOICE_STATE_UPDATE to Discord (rejoin), waits for voice
+     * credentials, then sends the current track + position + volume + paused
+     * state to the Lavalink node.
+     *
+     * @returns {Promise<this>}
+     * @emits playerResumed
+     * @since 1.0.13
+     */
+    async restart() {
+        if (!this.voiceChannel) {
+            this.riffy.emit("debug", `[Player ${this.guildId}] restart() called but no voiceChannel is set, aborting.`);
+            return this;
+        }
+
+        // 1. Re-inform the Discord gateway to rejoin the voice channel.
+        this.connect({
+            guildId: this.guildId,
+            voiceChannel: this.voiceChannel,
+            deaf: this.deaf,
+            mute: this.mute,
+        });
+
+        // 2. If we have a current encoded track, re-send it to the node at the
+        //    last known position. The queue is left untouched.
+        if (this.current && (this.current.track || this.current.encoded)) {
+            try {
+                await this.connection.resolve();
+            } catch (e) {
+                this.riffy.emit("debug", `[Player ${this.guildId}] restart(): voice credentials not ready: ${e.message}`);
+            }
+
+            const encoded = this.current.track || this.current.encoded;
+            await this.node.rest.updatePlayer({
+                guildId: this.guildId,
+                data: {
+                    track: { encoded },
+                    position: this.position || 0,
+                    volume: this.volume,
+                    paused: this.paused,
+                },
+            });
+
+            this.riffy.emit("debug", `[Player ${this.guildId}] restart(): resumed "${this.current.info?.title || "Unknown"}" at ${this.position || 0}ms (paused=${this.paused}).`);
+            this.riffy.emit("playerResumed", this);
+        } else if (this.queue.length > 0) {
+            // No current track but queue has items — start playback.
+            this.riffy.emit("debug", `[Player ${this.guildId}] restart(): no current track, starting next from queue.`);
+            try {
+                await this.play();
+            } catch (e) {
+                this.riffy.emit("debug", `[Player ${this.guildId}] restart(): play() failed: ${e.message}`);
+            }
+        } else {
+            this.riffy.emit("debug", `[Player ${this.guildId}] restart(): no current track and empty queue, nothing to resume.`);
+        }
+
+        return this;
+    }
+
+    /**
      * Moves the player to a new node.
      * @param {import("./Node").Node} newNode The node to move the player to.
      * @throws {TypeError} If no `newNode` is provided.

--- a/build/structures/Player.js
+++ b/build/structures/Player.js
@@ -535,10 +535,16 @@ class Player extends EventEmitter {
 
     /**
      * Destroys the player.
+     *
+     * @param {boolean} [skipRest=false] If true, skip the REST DELETE call to
+     *   Lavalink (use when the caller has already sent an awaited DELETE —
+     *   e.g. ResumeManager._failRestore — to avoid a wasteful duplicate).
      */
-    destroy() {
+    destroy(skipRest = false) {
         this.disconnect();
-        this.node.rest.destroyPlayer(this.guildId);
+        if (!skipRest) {
+            this.node.rest.destroyPlayer(this.guildId);
+        }
         this.removeAllListeners();
         this.connection = null;
         this.riffy.emit("playerDisconnect", this);
@@ -810,7 +816,11 @@ class Player extends EventEmitter {
             try {
                 await this.connection.resolve();
             } catch (e) {
-                this.riffy.emit("debug", `[Player ${this.guildId}] restart(): voice credentials not ready: ${e.message}`);
+                // Voice credentials never arrived — we cannot PATCH Lavalink.
+                // Do NOT fall through to updatePlayer (it would either fail
+                // or recreate an orphan player). Bail out.
+                this.riffy.emit("debug", `[Player ${this.guildId}] restart(): voice credentials not ready, aborting: ${e.message}`);
+                return this;
             }
 
             const encoded = this.current.track || this.current.encoded;

--- a/build/structures/Player.js
+++ b/build/structures/Player.js
@@ -167,7 +167,26 @@ class Player extends EventEmitter {
                 throw new Error(`Unable to play for Player with Guild Id ${this.guildId}, Track is not encoded and cannot be resolved.`);
             }
 
+            // resolve() can return undefined when no search results are found.
+            // Capture the track before reassignment so we can report it.
+            const unresolvedTrack = this.current;
             this.current = await this.current.resolve(this.riffy);
+
+            // If resolve() returned undefined/null, the track can't be played.
+            // Skip it (emit trackError for visibility) and try the next one,
+            // or emit queueEnd if the queue is now empty. This prevents the
+            // "Cannot destructure property 'track' of 'this.current' as it is
+            // undefined" TypeError that crashes the bot (issue #42).
+            if (!this.current) {
+                this.riffy.emit("debug", `[Player ${this.guildId}] Track "${unresolvedTrack.info?.title || "Unknown"}" could not be resolved, skipping.`);
+                this.riffy.emit("trackError", this, unresolvedTrack, { message: "Track could not be resolved (no search results found)" });
+                if (this.queue.length > 0) {
+                    return this.play();
+                }
+                this.playing = false;
+                this.riffy.emit("queueEnd", this);
+                return this;
+            }
         }
 
         if (!this.current?.track) {

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -791,21 +791,45 @@ class ResumeManager {
                 // _failRestore emits the event, and createConnection →
                 // updatePlayer can land before this DELETE completes). The
                 // guild-scoped DELETE just killed the replacement's Lavalink
-                // session. Re-send the replacement's current track to restore it.
+                // session — including its voice session. Re-send the replacement's
+                // voice credentials AND track to fully restore the Lavalink session.
+                //
+                // RACE FIX 5: the replacement's Connection records the voice
+                // credentials as already sent (#lastSentVoice === current voice),
+                // so it would skip re-sending them on a normal updatePlayer. We
+                // must include the voice data explicitly in this recovery PATCH
+                // so Lavalink re-establishes the voice connection — otherwise the
+                // replacement has a track but no voice session and produces no
+                // audio.
                 const afterDelete = this.riffy.players.get(player.guildId);
                 if (afterDelete && afterDelete !== player && afterDelete.current) {
-                    this.riffy.emit("debug", `[ResumeManager] Replacement player detected after orphan-cleanup DELETE for ${player.guildId}; re-sending its track to restore the Lavalink session.`);
+                    this.riffy.emit("debug", `[ResumeManager] Replacement player detected after orphan-cleanup DELETE for ${player.guildId}; re-sending its track + voice credentials to restore the Lavalink session.`);
                     try {
                         const replEncoded = afterDelete.current.track || afterDelete.current.encoded;
                         if (replEncoded) {
+                            // Build the recovery PATCH data with track + playback fields.
+                            const recoveryData = {
+                                track: { encoded: replEncoded },
+                                position: afterDelete.position || 0,
+                                volume: afterDelete.volume,
+                                paused: afterDelete.paused,
+                            };
+                            // Include voice credentials so Lavalink re-establishes
+                            // the voice session (the DELETE destroyed it). The
+                            // replacement's Connection won't re-send them on its own
+                            // because #lastSentVoice matches the current voice.
+                            const replConn = afterDelete.connection;
+                            if (replConn && replConn.voice && replConn.voice.sessionId && replConn.voice.endpoint && replConn.voice.token) {
+                                recoveryData.voice = {
+                                    sessionId: replConn.voice.sessionId,
+                                    endpoint: replConn.voice.endpoint,
+                                    token: replConn.voice.token,
+                                    channelId: replConn.voiceChannel ?? afterDelete.voiceChannel,
+                                };
+                            }
                             await afterDelete.node.rest.updatePlayer({
                                 guildId: player.guildId,
-                                data: {
-                                    track: { encoded: replEncoded },
-                                    position: afterDelete.position || 0,
-                                    volume: afterDelete.volume,
-                                    paused: afterDelete.paused,
-                                },
+                                data: recoveryData,
                             });
                         }
                     } catch (e) {

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -574,14 +574,37 @@ class ResumeManager {
     /**
      * Handle a failed restore: destroy any half-created player, remove the
      * guild from persisted state, and emit `playerRestoreFailed`.
+     *
+     * Sends an explicit, AWAITED DELETE to Lavalink (not just
+     * player.destroy(), which dispatches destroyPlayer() without awaiting
+     * it). This ensures the DELETE is ordered relative to any in-flight
+     * PATCH from _sendResumePayload — if the PATCH lands AFTER this DELETE,
+     * _sendResumePayload's post-PATCH orphan-cleanup DELETE removes the
+     * recreated Lavalink player.
+     *
      * @private
      */
     async _failRestore(guildId, reason, detail, state) {
         if (!guildId) return;
 
-        // Destroy the half-created player if it exists.
+        // Destroy the half-created player if it exists. We send an explicit,
+        // AWAITED DELETE to Lavalink here because Player.destroy() calls
+        // node.rest.destroyPlayer() WITHOUT awaiting it (the promise is
+        // discarded). That matters for this race: if a PATCH from
+        // _sendResumePayload is in flight when this fires, an unawaited
+        // DELETE could complete before OR after the PATCH lands — and if
+        // the PATCH lands AFTER the DELETE, it recreates an orphan Lavalink
+        // player. By awaiting our own DELETE here, the local cleanup is
+        // ordered relative to any PATCH, and _sendResumePayload's
+        // post-PATCH orphan-cleanup DELETE handles the other ordering.
         const player = this.riffy.players.get(guildId);
         if (player) {
+            // Send an awaited DELETE to Lavalink first (local cleanup below).
+            try {
+                await player.node.rest.destroyPlayer(guildId);
+            } catch (e) {
+                this.riffy.emit("debug", `[ResumeManager] destroyPlayer DELETE failed for ${guildId}: ${e.message}`);
+            }
             try {
                 player.destroy();
             } catch (e) {
@@ -626,12 +649,20 @@ class ResumeManager {
      * We must NOT swallow it and proceed to PATCH the track + emit
      * playerResumed — that would treat a failed restore as successful.
      *
-     * RACE FIX: If the restore was aborted (timeout / socketClosed) WHILE
+     * RACE FIX 1: If the restore was aborted (timeout / socketClosed) WHILE
      * we're awaiting connection.resolve(), the caller's _failRestore has
      * already destroyed the player + emitted playerRestoreFailed. If voice
      * creds then arrive, we must NOT PATCH Lavalink or emit playerResumed —
      * that would resurrect a destroyed player. The `isAborted` callback is
      * checked after the await and before the PATCH to bail out cleanly.
+     *
+     * RACE FIX 2: If the abort fires WHILE the PATCH is in flight, the
+     * PATCH may land on Lavalink AFTER _failRestore's DELETE (sent via
+     * player.destroy()), recreating an orphan Lavalink player that keeps
+     * playing. So after the PATCH resolves, if aborted, we send a DELETE
+     * to clean up any orphan Lavalink player the PATCH may have created.
+     * _failRestore also now awaits player.destroy() so the DELETE is
+     * ordered relative to the PATCH.
      *
      * @private
      * @param {() => boolean} [isAborted] Returns true if the restore was aborted.
@@ -641,7 +672,7 @@ class ResumeManager {
         // propagate so the restore is treated as a failure, not a success.
         await player.connection.resolve();
 
-        // RACE FIX: voice creds arrived, but the restore may have already
+        // RACE FIX 1: voice creds arrived, but the restore may have already
         // been aborted (timeout / socketClosed) while we were waiting. If so,
         // _failRestore has already destroyed the player + emitted
         // playerRestoreFailed. Bail out — do NOT PATCH or emit playerResumed.
@@ -666,10 +697,20 @@ class ResumeManager {
             },
         });
 
-        // Re-check after the PATCH too — if aborted during the PATCH request,
-        // don't flip state or emit playerResumed.
+        // RACE FIX 2: if aborted DURING the PATCH, the PATCH may have landed
+        // on Lavalink AFTER _failRestore's DELETE, recreating an orphan
+        // Lavalink player. Send a DELETE to clean it up. _failRestore has
+        // already destroyed the local player + emitted playerRestoreFailed;
+        // we just need to ensure Lavalink's side is also gone.
         if (isAborted()) {
-            this.riffy.emit("debug", `[ResumeManager] Restore aborted during PATCH for ${player.guildId}; not emitting playerResumed.`);
+            this.riffy.emit("debug", `[ResumeManager] Restore aborted during/after PATCH for ${player.guildId}; sending DELETE to clean up orphan Lavalink player.`);
+            try {
+                await player.node.rest.destroyPlayer(player.guildId);
+            } catch (e) {
+                // Best-effort — the orphan cleanup is a safety net; if the
+                // DELETE fails (e.g. player already gone), that's fine.
+                this.riffy.emit("debug", `[ResumeManager] Orphan-cleanup DELETE failed for ${player.guildId}: ${e.message}`);
+            }
             return;
         }
 

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -1,4 +1,3 @@
-const fs = require("node:fs");
 const path = require("node:path");
 const { Track } = require("./Track");
 const { StorageAdapter } = require("./storage/StorageAdapter");
@@ -171,6 +170,9 @@ class ResumeManager {
     _validatePlayerState(guildId, state) {
         if (!state || typeof state !== "object") return { ok: false, reason: "not an object" };
         if (typeof state.guildId !== "string" || !state.guildId) return { ok: false, reason: "missing guildId" };
+        // Cross-check: the stored state's guildId must match the key it was
+        // stored under. A mismatch indicates corruption or a storage bug.
+        if (guildId && state.guildId !== guildId) return { ok: false, reason: `guildId mismatch (key=${guildId}, state=${state.guildId})` };
         if (typeof state.voiceChannel !== "string" || !state.voiceChannel) return { ok: false, reason: "missing voiceChannel" };
         if (state.volume !== undefined && typeof state.volume !== "number") return { ok: false, reason: "volume is not a number" };
         if (state.position !== undefined && typeof state.position !== "number") return { ok: false, reason: "position is not a number" };
@@ -201,16 +203,22 @@ class ResumeManager {
      * Safely serialize a Track's info into a JSON-safe plain object.
      * The `requester` is reduced to a primitive/id (it is usually a Discord
      * User object which is not JSON-serializable due to circular refs).
+     *
+     * Field names match Lavalink v4's raw track info (isSeekable, isStream)
+     * so the serialized object can be passed directly to `new Track({ info })`
+     * on restore — the Track constructor reads info.isSeekable / info.isStream.
+     * The Track class's runtime info object uses seekable/stream (mapped from
+     * the Lavalink names), so we read those here and write the Lavalink names.
      * @private
      */
     _safeSerializeInfo(info) {
         if (!info) return null;
         const out = {
             identifier: info.identifier ?? null,
-            isSeekable: info.seekable ?? false,
+            isSeekable: info.seekable ?? info.isSeekable ?? false,
             author: info.author ?? null,
             length: info.length ?? 0,
-            isStream: info.stream ?? false,
+            isStream: info.stream ?? info.isStream ?? false,
             position: info.position ?? 0,
             title: info.title ?? null,
             uri: info.uri ?? null,
@@ -397,7 +405,10 @@ class ResumeManager {
         const guildIds = Object.keys(this._state.players || {});
         if (!guildIds.length) {
             this.riffy.emit("debug", `[ResumeManager] No saved players to restore.`);
-            if (this.clearOnRestore) { await this.storage.clear().catch(() => {}); }
+            if (this.clearOnRestore) {
+                await this.storage.clear().catch(() => {});
+                this._restoredFully = true;
+            }
             return [];
         }
 
@@ -861,6 +872,17 @@ class ResumeManager {
      */
     get snapshot() {
         return JSON.parse(JSON.stringify(this._state));
+    }
+
+    /**
+     * Whether restoreAll() has completed AND clearOnRestore wiped the store.
+     * Useful for callers to check if a full restore+clear cycle happened
+     * (e.g. to decide whether to re-arm auto-restore after a manual
+     * load() + restoreAll() cycle).
+     * @since 1.0.15
+     */
+    get isFullyRestored() {
+        return this._restoredFully;
     }
 }
 

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -705,9 +705,15 @@ class ResumeManager {
         }
 
         // Remove from persisted state so it isn't retried on every restart.
+        // Note: player.destroy(true) above emits playerDisconnect → the
+        // attachListeners hook already called removePlayer(guildId) which
+        // deletes from _state.players + calls storage.remove(). This block
+        // is a safety net for the case where the hook isn't attached (e.g.
+        // attachListeners wasn't called, or destroy() didn't emit the event).
+        // The guard prevents a redundant storage.remove() call when
+        // clearOnRestore would wipe everything anyway.
         if (this._state.players[guildId]) {
             delete this._state.players[guildId];
-            // Persist the cleanup immediately (unless clearOnRestore will wipe all).
             if (!this.clearOnRestore) {
                 this.storage.remove(guildId).catch((err) => {
                     this.riffy.emit("debug", `[ResumeManager] storage.remove failed for ${guildId} after failed restore: ${err.message}`);
@@ -781,8 +787,12 @@ class ResumeManager {
 
         const encoded = state.current?.encoded || player.current?.track || player.current?.encoded;
         if (!encoded) {
-            this.riffy.emit("debug", `[ResumeManager] No encoded track to resume for ${player.guildId}`);
-            return;
+            // No encoded track to resume — throw so restorePlayer's catch
+            // calls _failRestore (destroys the player, emits
+            // playerRestoreFailed) instead of falling through to
+            // resolve(player) + emit playerResumed, which would be a false
+            // success (bot rejoins voice channel but produces no audio).
+            throw new Error(`No encoded track to resume for ${player.guildId}`);
         }
 
         await player.node.rest.updatePlayer({
@@ -922,8 +932,19 @@ class ResumeManager {
         // Store riffy event handler refs so destroy() can unregister them.
         const onTrackStart = (player) => this.savePlayer(player);
         const onTrackEnd = (player) => this.savePlayer(player);
-        const onQueueEnd = (player) => this.savePlayer(player);
-        const onPlayerCreate = (player) => this.savePlayer(player);
+        // queueEnd: the queue is empty + nothing playing. Persisting this idle
+        // state (current: null, queue: []) means on restart the bot rejoins the
+        // voice channel and sits idle — playerResumed fires but no audio plays.
+        // Instead, remove the guild from the store so it's NOT restored.
+        const onQueueEnd = (player) => this.removePlayer(player.guildId);
+        // playerCreate: only save if there's something worth restoring (a
+        // current track or a non-empty queue). A freshly created player with
+        // no track + empty queue isn't worth persisting.
+        const onPlayerCreate = (player) => {
+            if (player.current || (player.queue && player.queue.length > 0)) {
+                this.savePlayer(player);
+            }
+        };
         const onPlayerMove = (player) => this.savePlayer(player);
         // Hook playerDisconnect (emitted by Player.destroy()) instead of just
         // playerDestroy (only emitted by Riffy.destroyPlayer()). If a user or

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -713,18 +713,26 @@ class ResumeManager {
 
         // RACE FIX 2 + 3: if aborted DURING/AFTER the PATCH, the PATCH may
         // have landed on Lavalink AFTER _failRestore's DELETE, recreating an
-        // orphan Lavalink player. Send a DELETE to clean it up — BUT only if
-        // the player instance we PATCHed is still the one registered for
-        // this guild. If _failRestore emitted playerRestoreFailed and the
-        // user's handler created a REPLACEMENT player, this.players.get()
-        // now points at a different instance; a guild-scoped DELETE would
-        // kill the replacement's Lavalink session (review: "replacement
-        // player's Lavalink session silently stopped").
+        // orphan Lavalink player. Send a DELETE to clean it up — UNLESS a
+        // REPLACEMENT player now exists for this guild (which would be killed
+        // by a guild-scoped DELETE).
+        //
+        // Three cases after the PATCH resolves and isAborted() is true:
+        //   1. currentPlayer === player        → original still registered, no
+        //      replacement. DELETE the orphan.
+        //   2. currentPlayer === undefined     → original was removed by
+        //      _failRestore, no replacement. DELETE the orphan. (This was the
+        //      bug: the old `=== player` check treated `undefined` as "a
+        //      replacement exists" and skipped the DELETE, leaving an orphan
+        //      Lavalink player playing after playerRestoreFailed.)
+        //   3. currentPlayer !== player && !== undefined → a REPLACEMENT
+        //      player exists. Skip the DELETE — it would kill the replacement.
         if (isAborted()) {
             const currentPlayer = this.riffy.players.get(player.guildId);
-            if (currentPlayer === player) {
-                // No replacement — safe to delete the orphan we may have
-                // just recreated on Lavalink.
+            const replacementExists = currentPlayer !== undefined && currentPlayer !== player;
+            if (!replacementExists) {
+                // No replacement (original still registered OR already removed) —
+                // safe to delete the orphan we may have just recreated on Lavalink.
                 this.riffy.emit("debug", `[ResumeManager] Restore aborted during/after PATCH for ${player.guildId}; sending DELETE to clean up orphan Lavalink player.`);
                 try {
                     await player.node.rest.destroyPlayer(player.guildId);
@@ -733,7 +741,8 @@ class ResumeManager {
                 }
             } else {
                 // A replacement player exists for this guild — do NOT send
-                // a guild-scoped DELETE, it would kill the replacement.
+                // a guild-scoped DELETE, it would kill the replacement's
+                // Lavalink session.
                 this.riffy.emit("debug", `[ResumeManager] Restore aborted after PATCH for ${player.guildId}, but a replacement player is now registered; skipping orphan-cleanup DELETE to avoid killing the replacement's Lavalink session.`);
             }
             return;

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -323,18 +323,28 @@ class ResumeManager {
     }
 
     /**
-     * Reconstruct a Track object from serialized data.
+     * Reconstruct a Track object from serialized data. Async because the
+     * requesterResolver may return a Promise (e.g. client.users.fetch(id)).
      * @private
      */
-    _rebuildTrack(data, node) {
+    async _rebuildTrack(data, node) {
         if (!data) return null;
         const encoded = data.encoded || null;
         let requester = data.info?.requester ?? null;
         if (requester !== null && this.requesterResolver) {
             try {
-                requester = this.requesterResolver(requester) ?? requester;
-            } catch (_) {
-                /* keep primitive requester */
+                const resolved = this.requesterResolver(requester);
+                // Support both sync and async resolvers — await a Promise,
+                // use the value directly otherwise. Fall back to the
+                // primitive requester if the resolver returns null/undefined.
+                if (resolved instanceof Promise) {
+                    requester = (await resolved) ?? requester;
+                } else {
+                    requester = resolved ?? requester;
+                }
+            } catch (e) {
+                // Resolver threw (e.g. user not found) — keep primitive requester.
+                this.riffy.emit("debug", `[ResumeManager] requesterResolver threw for guild: ${e.message}`);
             }
         }
         const track = new Track(
@@ -462,14 +472,14 @@ class ResumeManager {
                 // 3. Rebuild the queue.
                 if (Array.isArray(state.queue)) {
                     for (const t of state.queue) {
-                        const rebuilt = this._rebuildTrack(t, node);
+                        const rebuilt = await this._rebuildTrack(t, node);
                         if (rebuilt) player.queue.add(rebuilt);
                     }
                 }
 
                 // 4. Restore current track + seek to the saved position.
                 if (state.current && (state.current.encoded || (state.current.info && state.current.info.identifier))) {
-                    const currentTrack = this._rebuildTrack(state.current, node);
+                    const currentTrack = await this._rebuildTrack(state.current, node);
                     player.current = currentTrack;
                     player.position = state.position || 0;
                     player.paused = state.paused ?? false;
@@ -584,14 +594,19 @@ class ResumeManager {
 
     /**
      * Wait for voice credentials then send the track + seek position to the node.
+     *
+     * IMPORTANT: If connection.resolve() rejects (voice credentials never
+     * arrived — channel deleted, bot kicked, no Connect permission), the
+     * error is re-thrown so restorePlayer's catch block calls _failRestore.
+     * We must NOT swallow it and proceed to PATCH the track + emit
+     * playerResumed — that would treat a failed restore as successful.
+     *
      * @private
      */
     async _sendResumePayload(player, state) {
-        try {
-            await player.connection.resolve();
-        } catch (e) {
-            this.riffy.emit("debug", `[ResumeManager] Voice connection not ready for ${player.guildId}; attempting payload anyway: ${e.message}`);
-        }
+        // This throws if Discord doesn't supply voice credentials. Let it
+        // propagate so the restore is treated as a failure, not a success.
+        await player.connection.resolve();
 
         const encoded = state.current?.encoded || player.current?.track || player.current?.encoded;
         if (!encoded) {

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -792,7 +792,8 @@ class ResumeManager {
                 // updatePlayer can land before this DELETE completes). The
                 // guild-scoped DELETE just killed the replacement's Lavalink
                 // session — including its voice session. Re-send the replacement's
-                // voice credentials AND track to fully restore the Lavalink session.
+                // voice credentials AND track (if any) to fully restore the
+                // Lavalink session.
                 //
                 // RACE FIX 5: the replacement's Connection records the voice
                 // credentials as already sent (#lastSentVoice === current voice),
@@ -801,37 +802,51 @@ class ResumeManager {
                 // so Lavalink re-establishes the voice connection — otherwise the
                 // replacement has a track but no voice session and produces no
                 // audio.
+                //
+                // RACE FIX 6: the replacement may have established voice
+                // credentials but NOT yet assigned a current track (it just
+                // joined the voice channel, hasn't started playing). The previous
+                // `afterDelete.current` guard would skip the recovery PATCH
+                // entirely in that case — but the DELETE still killed the
+                // replacement's voice session, and without recovery the
+                // replacement would remain registered locally with no audio and
+                // no way to restore the voice session (Connection sees unchanged
+                // creds as already sent). So the guard is now based on voice
+                // credentials, not on a current track. The track is optional in
+                // the recovery data.
                 const afterDelete = this.riffy.players.get(player.guildId);
-                if (afterDelete && afterDelete !== player && afterDelete.current) {
-                    this.riffy.emit("debug", `[ResumeManager] Replacement player detected after orphan-cleanup DELETE for ${player.guildId}; re-sending its track + voice credentials to restore the Lavalink session.`);
+                const replConn = afterDelete?.connection;
+                const hasVoice = !!(replConn && replConn.voice && replConn.voice.sessionId && replConn.voice.endpoint && replConn.voice.token);
+                if (afterDelete && afterDelete !== player && hasVoice) {
+                    this.riffy.emit("debug", `[ResumeManager] Replacement player detected after orphan-cleanup DELETE for ${player.guildId}; re-sending its${afterDelete.current ? " track +" : ""} voice credentials to restore the Lavalink session.`);
                     try {
-                        const replEncoded = afterDelete.current.track || afterDelete.current.encoded;
-                        if (replEncoded) {
-                            // Build the recovery PATCH data with track + playback fields.
-                            const recoveryData = {
-                                track: { encoded: replEncoded },
-                                position: afterDelete.position || 0,
-                                volume: afterDelete.volume,
-                                paused: afterDelete.paused,
-                            };
-                            // Include voice credentials so Lavalink re-establishes
-                            // the voice session (the DELETE destroyed it). The
-                            // replacement's Connection won't re-send them on its own
-                            // because #lastSentVoice matches the current voice.
-                            const replConn = afterDelete.connection;
-                            if (replConn && replConn.voice && replConn.voice.sessionId && replConn.voice.endpoint && replConn.voice.token) {
-                                recoveryData.voice = {
-                                    sessionId: replConn.voice.sessionId,
-                                    endpoint: replConn.voice.endpoint,
-                                    token: replConn.voice.token,
-                                    channelId: replConn.voiceChannel ?? afterDelete.voiceChannel,
-                                };
+                        // Build the recovery PATCH data. Track + playback fields
+                        // are only included if the replacement has a current track.
+                        const recoveryData = {};
+                        if (afterDelete.current) {
+                            const replEncoded = afterDelete.current.track || afterDelete.current.encoded;
+                            if (replEncoded) {
+                                recoveryData.track = { encoded: replEncoded };
+                                recoveryData.position = afterDelete.position || 0;
+                                recoveryData.volume = afterDelete.volume;
+                                recoveryData.paused = afterDelete.paused;
                             }
-                            await afterDelete.node.rest.updatePlayer({
-                                guildId: player.guildId,
-                                data: recoveryData,
-                            });
                         }
+                        // Voice credentials are always included when present —
+                        // this is the critical part that restores the voice
+                        // session the DELETE just destroyed. The replacement's
+                        // Connection won't re-send them on its own because
+                        // #lastSentVoice matches the current voice.
+                        recoveryData.voice = {
+                            sessionId: replConn.voice.sessionId,
+                            endpoint: replConn.voice.endpoint,
+                            token: replConn.voice.token,
+                            channelId: replConn.voiceChannel ?? afterDelete.voiceChannel,
+                        };
+                        await afterDelete.node.rest.updatePlayer({
+                            guildId: player.guildId,
+                            data: recoveryData,
+                        });
                     } catch (e) {
                         this.riffy.emit("debug", `[ResumeManager] Re-PATCH of replacement failed for ${player.guildId}: ${e.message}`);
                     }

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -1,0 +1,644 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { Track } = require("./Track");
+
+/**
+ * ResumeManager
+ *
+ * Provides client-restart auto-resume for Riffy. Persists player state
+ * (voice channel, text channel, current track, playback position, volume,
+ * loop mode, paused state, and the full queue) to a JSON file on disk and
+ * restores all players after the bot process restarts.
+ *
+ * On restore it will:
+ *   1. Re-create the player connection (rejoin the same voice channel).
+ *   2. Rebuild the queue from the persisted encoded track strings.
+ *   3. Re-send the current track to the Lavalink node at the last known
+ *      position (seek), restoring volume and paused state.
+ *
+ * This is distinct from Node-level `autoResume` (which only re-establishes
+ * players when the Lavalink WebSocket reconnects). ResumeManager survives a
+ * full process restart.
+ */
+class ResumeManager {
+    /**
+     * @param {import("./Riffy").Riffy} riffy
+     * @param {Object} [options]
+     * @param {boolean} [options.enabled=false] Enable client-restart resume.
+     * @param {string} [options.filePath] Path to the state JSON file. Defaults to `<cwd>/riffy-state.json`.
+     * @param {number} [options.saveInterval=3000] Debounce window (ms) for disk writes.
+     * @param {(requester: any) => any} [options.requesterResolver] Optional function to rebuild a requester object from the persisted value.
+     */
+    constructor(riffy, options = {}) {
+        this.riffy = riffy;
+        this.enabled = options.enabled ?? false;
+        this.filePath = options.filePath || path.join(process.cwd(), "riffy-state.json");
+        this.saveInterval = typeof options.saveInterval === "number" ? options.saveInterval : 3000;
+        this.requesterResolver = typeof options.requesterResolver === "function" ? options.requesterResolver : null;
+        /**
+         * When `true`, the persisted state file is deleted from disk once a
+         * full restore completes successfully. This prevents stale state from
+         * accumulating and being re-applied on every subsequent restart.
+         *
+         * The in-memory state is also wiped, so a second restoreAll() call
+         * becomes a no-op (returns `[]`). New player activity after the
+         * restore will be persisted fresh as usual.
+         *
+         * Default: `false` (state is kept across restarts).
+         */
+        this.clearOnRestore = options.clearOnRestore ?? false;
+        /**
+         * Maximum time (ms) to wait for voice credentials when restoring a
+         * single player. If Discord doesn't reply with a VOICE_SERVER_UPDATE
+         * in time (e.g. the voice channel was deleted, the bot was kicked,
+         * or it lacks Connect permission), the restore for that guild is
+         * aborted, the half-created player is destroyed, the guild is
+         * removed from persisted state, and a `playerRestoreFailed` event
+         * is emitted with reason `"timeout"`.
+         *
+         * Default: `15000` (15 seconds).
+         */
+        this.restoreTimeout = typeof options.restoreTimeout === "number" ? options.restoreTimeout : 15000;
+
+        /** @type {{ version: number, savedAt: number, players: Record<string, any> }} */
+        this._state = { version: 1, savedAt: 0, players: {} };
+        this._saveTimer = null;
+        this._dirty = false;
+        this._restored = false;
+        this._restoredFully = false;
+        this._listenersAttached = false;
+        /** @type {Map<string, (reason: string, detail?: any) => void>} guildId -> reject fn for active restores */
+        this._pendingRestores = new Map();
+    }
+
+    /**
+     * Load persisted state from disk into memory. Corrupt or partial writes
+     * (e.g. from a crash mid-flush or storage loss) are handled gracefully:
+     * if the file can't be parsed, or individual player entries are missing
+     * required fields, those entries are dropped and logged rather than
+     * crashing the restore.
+     * @returns {boolean} Whether any valid players were loaded.
+     */
+    load() {
+        if (!this.enabled) return false;
+        try {
+            if (!fs.existsSync(this.filePath)) return false;
+            const raw = fs.readFileSync(this.filePath, "utf-8");
+            const parsed = JSON.parse(raw);
+            if (!parsed || typeof parsed !== "object" || !parsed.players) return false;
+
+            const validPlayers = {};
+            let dropped = 0;
+            for (const [guildId, state] of Object.entries(parsed.players)) {
+                const validation = this._validatePlayerState(guildId, state);
+                if (validation.ok) {
+                    validPlayers[guildId] = state;
+                } else {
+                    dropped++;
+                    this.riffy.emit("debug", `[ResumeManager] Dropped invalid persisted entry for guild ${guildId}: ${validation.reason}`);
+                }
+            }
+
+            this._state = { version: 1, savedAt: parsed.savedAt || 0, players: validPlayers };
+            const count = Object.keys(validPlayers).length;
+            this.riffy.emit("debug", `[ResumeManager] Loaded state for ${count} player(s) from ${this.filePath}${dropped ? ` (dropped ${dropped} invalid entry/entries)` : ""}`);
+
+            // If we dropped invalid entries, persist the cleaned-up state.
+            if (dropped > 0) this.save(true);
+            return count > 0;
+        } catch (e) {
+            this.riffy.emit("debug", `[ResumeManager] Failed to load state from ${this.filePath} (likely corrupt or partial write): ${e.message}`);
+            // Move the corrupt file aside so future saves aren't blocked by it.
+            try {
+                if (fs.existsSync(this.filePath)) {
+                    const backup = this.filePath + ".corrupt-" + Date.now();
+                    fs.renameSync(this.filePath, backup);
+                    this.riffy.emit("debug", `[ResumeManager] Moved corrupt state file to ${backup}`);
+                }
+            } catch (_) {
+                /* ignore */
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Validate a single persisted player state object. Guards against partial
+     * writes / storage corruption producing malformed entries that would
+     * crash _rebuildTrack or restorePlayer.
+     * @private
+     * @returns {{ ok: boolean, reason?: string }}
+     */
+    _validatePlayerState(guildId, state) {
+        if (!state || typeof state !== "object") return { ok: false, reason: "not an object" };
+        if (typeof state.guildId !== "string" || !state.guildId) return { ok: false, reason: "missing guildId" };
+        if (typeof state.voiceChannel !== "string" || !state.voiceChannel) return { ok: false, reason: "missing voiceChannel" };
+        if (state.volume !== undefined && typeof state.volume !== "number") return { ok: false, reason: "volume is not a number" };
+        if (state.position !== undefined && typeof state.position !== "number") return { ok: false, reason: "position is not a number" };
+        if (state.paused !== undefined && typeof state.paused !== "boolean") return { ok: false, reason: "paused is not a boolean" };
+        if (state.queue !== undefined && !Array.isArray(state.queue)) return { ok: false, reason: "queue is not an array" };
+        if (state.current !== undefined && state.current !== null && typeof state.current !== "object") return { ok: false, reason: "current is not an object" };
+        return { ok: true };
+    }
+
+    /**
+     * Schedule a debounced write to disk.
+     * @param {boolean} [immediate=false] If true, flush synchronously right now.
+     */
+    save(immediate = false) {
+        if (!this.enabled) return;
+        this._dirty = true;
+        if (immediate) {
+            this._flush();
+            return;
+        }
+        if (this._saveTimer) return;
+        this._saveTimer = setTimeout(() => {
+            this._saveTimer = null;
+            this._flush();
+        }, this.saveInterval);
+    }
+
+    /** @private */
+    _flush() {
+        if (!this._dirty) return;
+        this._dirty = false;
+        try {
+            this._state.savedAt = Date.now();
+            const dir = path.dirname(this.filePath);
+            if (dir && !fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+            fs.writeFileSync(this.filePath, JSON.stringify(this._state, null, 2), "utf-8");
+        } catch (e) {
+            this.riffy.emit("debug", `[ResumeManager] Failed to save state to ${this.filePath}: ${e.message}`);
+        }
+    }
+
+    /**
+     * Safely serialize a Track's info into a JSON-safe plain object.
+     * The `requester` is reduced to a primitive/id (it is usually a Discord
+     * User object which is not JSON-serializable due to circular refs).
+     * @private
+     */
+    _safeSerializeInfo(info) {
+        if (!info) return null;
+        const out = {
+            identifier: info.identifier ?? null,
+            isSeekable: info.seekable ?? false,
+            author: info.author ?? null,
+            length: info.length ?? 0,
+            isStream: info.stream ?? false,
+            position: info.position ?? 0,
+            title: info.title ?? null,
+            uri: info.uri ?? null,
+            sourceName: info.sourceName ?? null,
+            isrc: info.isrc ?? null,
+            artworkUrl: null,
+        };
+        // Resolve thumbnail via the getter (returns a URL string or null).
+        try {
+            const thumb = typeof info.thumbnail === "string" ? info.thumbnail : (info._cachedThumbnail ?? null);
+            out.artworkUrl = thumb;
+        } catch (_) {
+            out.artworkUrl = null;
+        }
+        // Persist requester only in a serializable form.
+        const req = info.requester;
+        if (req !== undefined && req !== null) {
+            if (typeof req === "string" || typeof req === "number" || typeof req === "boolean") {
+                out.requester = req;
+            } else if (typeof req === "object" && req.id) {
+                out.requester = req.id;
+            } else {
+                out.requester = null;
+            }
+        } else {
+            out.requester = null;
+        }
+        return out;
+    }
+
+    /**
+     * Serialize a player into a JSON-safe object.
+     * @param {import("./Player").Player} player
+     */
+    serializePlayer(player) {
+        if (!player || !player.guildId) return null;
+
+        const current = player.current
+            ? {
+                  encoded: player.current.track || player.current.encoded || null,
+                  info: this._safeSerializeInfo(player.current.info),
+                  pluginInfo: player.current.pluginInfo || null,
+              }
+            : null;
+
+        const queue = (player.queue || []).map((t) => ({
+            encoded: t.track || t.encoded || null,
+            info: this._safeSerializeInfo(t.info),
+            pluginInfo: t.pluginInfo || null,
+        }));
+
+        return {
+            guildId: player.guildId,
+            voiceChannel: player.voiceChannel ?? null,
+            textChannel: player.textChannel ?? null,
+            volume: player.volume ?? 100,
+            loop: player.loop ?? "none",
+            paused: player.paused ?? false,
+            playing: player.playing ?? false,
+            position: player.position || 0,
+            deaf: player.deaf ?? true,
+            mute: player.mute ?? false,
+            current,
+            queue,
+            savedAt: Date.now(),
+        };
+    }
+
+    /**
+     * Update stored state for a single player and schedule a save.
+     * @param {import("./Player").Player} player
+     */
+    savePlayer(player) {
+        if (!this.enabled) return;
+        const serialized = this.serializePlayer(player);
+        if (!serialized) return;
+        this._state.players[player.guildId] = serialized;
+        this.save();
+    }
+
+    /**
+     * Remove a player from persisted state (e.g. when destroyed).
+     * @param {string} guildId
+     */
+    removePlayer(guildId) {
+        if (!this.enabled) return;
+        if (this._state.players[guildId]) {
+            delete this._state.players[guildId];
+            this.save();
+        }
+    }
+
+    /**
+     * Reconstruct a Track object from serialized data.
+     * @private
+     */
+    _rebuildTrack(data, node) {
+        if (!data) return null;
+        const encoded = data.encoded || null;
+        let requester = data.info?.requester ?? null;
+        if (requester !== null && this.requesterResolver) {
+            try {
+                requester = this.requesterResolver(requester) ?? requester;
+            } catch (_) {
+                /* keep primitive requester */
+            }
+        }
+        const track = new Track(
+            { encoded, info: data.info || {}, pluginInfo: data.pluginInfo || {} },
+            requester,
+            node
+        );
+        return track;
+    }
+
+    /**
+     * Restore all players from persisted state. Should be called after Riffy
+     * is initialized and at least one node has emitted "ready".
+     *
+     * If `clearOnRestore` is `true`, the persisted state file is deleted from
+     * disk once the restore completes (whether or not all players were
+     * restored successfully — failed entries are dropped from the in-memory
+     * state, and the file is removed so it can't be re-applied on the next
+     * restart). New player activity after this point is persisted fresh.
+     *
+     * @returns {Promise<Array<import("./Player").Player>>}
+     */
+    async restoreAll() {
+        if (!this.enabled) return [];
+        if (this._restored) return [];
+        this._restored = true;
+
+        const guildIds = Object.keys(this._state.players || {});
+        if (!guildIds.length) {
+            this.riffy.emit("debug", `[ResumeManager] No saved players to restore.`);
+            // Still honor clearOnRestore so a leftover empty/stale file is removed.
+            if (this.clearOnRestore) this._clearDiskFile();
+            return [];
+        }
+
+        this.riffy.emit("debug", `[ResumeManager] Restoring ${guildIds.length} player(s)...`);
+        const restored = [];
+
+        for (const guildId of guildIds) {
+            const state = this._state.players[guildId];
+            try {
+                const player = await this.restorePlayer(state);
+                if (player) restored.push(player);
+            } catch (e) {
+                this.riffy.emit("debug", `[ResumeManager] Failed to restore player ${guildId}: ${e.message}`);
+                delete this._state.players[guildId];
+            }
+        }
+
+        this.riffy.emit("debug", `[ResumeManager] Restore complete (${restored.length}/${guildIds.length} succeeded).`);
+
+        if (this.clearOnRestore) {
+            // Wipe in-memory state and delete the on-disk file so it isn't
+            // re-applied on the next restart. Fresh state will be written as
+            // new player activity happens.
+            this._state = { version: 1, savedAt: 0, players: {} };
+            this._dirty = false;
+            if (this._saveTimer) { clearTimeout(this._saveTimer); this._saveTimer = null; }
+            this._clearDiskFile();
+            this._restoredFully = true;
+            this.riffy.emit("debug", `[ResumeManager] clearOnRestore enabled — state file removed, in-memory state wiped.`);
+        } else {
+            this.save(true);
+        }
+
+        return restored;
+    }
+
+    /**
+     * Delete the persisted state file from disk (if it exists).
+     * @private
+     */
+    _clearDiskFile() {
+        try {
+            if (fs.existsSync(this.filePath)) {
+                fs.unlinkSync(this.filePath);
+                this.riffy.emit("debug", `[ResumeManager] Deleted state file: ${this.filePath}`);
+            }
+        } catch (e) {
+            this.riffy.emit("debug", `[ResumeManager] Failed to delete state file ${this.filePath}: ${e.message}`);
+        }
+    }
+
+    /**
+     * Restore a single player from serialized state. Wraps the whole flow in
+     * a timeout (`restoreTimeout`); if Discord doesn't grant voice credentials
+     * in time (channel deleted, bot kicked, missing Connect permission), the
+     * restore is aborted, the half-created player is destroyed, the guild is
+     * removed from persisted state, and `playerRestoreFailed` is emitted.
+     *
+     * @param {any} state
+     * @returns {Promise<import("./Player").Player | null>}
+     */
+    async restorePlayer(state) {
+        if (!state || !state.guildId || !state.voiceChannel) {
+            await this._failRestore(state?.guildId ?? null, "invalid_state", "Missing guildId or voiceChannel", state);
+            return null;
+        }
+
+        // Skip if a player already exists for this guild.
+        if (this.riffy.players.has(state.guildId)) {
+            this.riffy.emit("debug", `[ResumeManager] Player already exists for ${state.guildId}, skipping restore.`);
+            return this.riffy.players.get(state.guildId);
+        }
+
+        const node = this.riffy.bestNode || this.riffy.leastUsedNodes[0];
+        if (!node) {
+            await this._failRestore(state.guildId, "no_nodes", "No connected nodes available to restore player", state);
+            return null;
+        }
+
+        const guildId = state.guildId;
+
+        // Set up a promise that rejects on timeout OR on socketClosed during
+        // the restore window. This lets us abort early instead of always
+        // waiting the full restoreTimeout.
+        let settleTimer = null;
+        let socketClosedHandler = null;
+        const restorePromise = new Promise(async (resolve, reject) => {
+            // Register the reject so socketClosed / timeout can abort.
+            this._pendingRestores.set(guildId, (reason, detail) => reject({ reason, detail }));
+
+            try {
+                // 1. Re-create the connection -> sends VOICE_STATE_UPDATE to rejoin.
+                const player = this.riffy.createConnection({
+                    guildId,
+                    voiceChannel: state.voiceChannel,
+                    textChannel: state.textChannel,
+                    deaf: state.deaf ?? true,
+                    mute: state.mute ?? false,
+                    defaultVolume: state.volume ?? 100,
+                    loop: state.loop ?? "none",
+                });
+
+                // 2. Restore volume & loop mode.
+                if (typeof state.volume === "number") player.volume = state.volume;
+                if (state.loop) player.loop = state.loop;
+
+                // 3. Rebuild the queue.
+                if (Array.isArray(state.queue)) {
+                    for (const t of state.queue) {
+                        const rebuilt = this._rebuildTrack(t, node);
+                        if (rebuilt) player.queue.add(rebuilt);
+                    }
+                }
+
+                // 4. Restore current track + seek to the saved position.
+                if (state.current && (state.current.encoded || (state.current.info && state.current.info.identifier))) {
+                    const currentTrack = this._rebuildTrack(state.current, node);
+                    player.current = currentTrack;
+                    player.position = state.position || 0;
+                    player.paused = state.paused ?? false;
+
+                    // Send the resume payload once voice credentials arrive.
+                    await this._sendResumePayload(player, state);
+                } else if (player.queue.length > 0) {
+                    try {
+                        await player.play();
+                    } catch (e) {
+                        this.riffy.emit("debug", `[ResumeManager] Auto-play after restore failed for ${guildId}: ${e.message}`);
+                    }
+                }
+
+                this.riffy.emit(
+                    "debug",
+                    `[ResumeManager] Restored player for guild ${guildId} (voice=${state.voiceChannel}, queue=${player.queue.length}, position=${state.position || 0}ms, paused=${state.paused ?? false})`
+                );
+                resolve(player);
+            } catch (err) {
+                reject({ reason: "error", detail: err });
+            }
+        });
+
+        // Timeout: if voice credentials never arrive, abort.
+        settleTimer = setTimeout(() => {
+            const rejectFn = this._pendingRestores.get(guildId);
+            if (rejectFn) {
+                this.riffy.emit("debug", `[ResumeManager] Restore timed out for ${guildId} after ${this.restoreTimeout}ms (channel deleted / no permission / bot kicked?).`);
+                rejectFn("timeout", `Voice credentials not received within ${this.restoreTimeout}ms`);
+            }
+        }, this.restoreTimeout);
+
+        // Listen for socketClosed during the restore window — Discord sends
+        // these when the bot can't connect (permission denied, channel gone).
+        socketClosedHandler = (player, payload) => {
+            if (player.guildId !== guildId) return;
+            // Codes that indicate the bot can't join:
+            //   4006 = session invalid, 4014 = server not available / disconnected,
+            //   4009 = session timeout, 4015 = server crash
+            const fatalCodes = [4006, 4009, 4014, 4015];
+            if (fatalCodes.includes(payload.code)) {
+                const rejectFn = this._pendingRestores.get(guildId);
+                if (rejectFn) {
+                    this.riffy.emit("debug", `[ResumeManager] Voice socket closed (code ${payload.code}) during restore for ${guildId}, aborting.`);
+                    rejectFn("socket_closed", `Voice socket closed: code ${payload.code} (${payload.reason || "no reason"})`);
+                }
+            }
+        };
+        this.riffy.on("socketClosed", socketClosedHandler);
+
+        try {
+            const player = await restorePromise;
+            return player;
+        } catch (err) {
+            const reason = err?.reason || "error";
+            const detail = err?.detail instanceof Error ? err.detail.message : (err?.detail || "unknown");
+            await this._failRestore(guildId, reason, detail, state);
+            return null;
+        } finally {
+            clearTimeout(settleTimer);
+            this._pendingRestores.delete(guildId);
+            if (socketClosedHandler) this.riffy.off("socketClosed", socketClosedHandler);
+        }
+    }
+
+    /**
+     * Handle a failed restore: destroy any half-created player, remove the
+     * guild from persisted state, and emit `playerRestoreFailed`.
+     * @private
+     */
+    async _failRestore(guildId, reason, detail, state) {
+        if (!guildId) return;
+
+        // Destroy the half-created player if it exists.
+        const player = this.riffy.players.get(guildId);
+        if (player) {
+            try {
+                player.destroy();
+            } catch (e) {
+                this.riffy.emit("debug", `[ResumeManager] Error destroying failed player for ${guildId}: ${e.message}`);
+            }
+            // Safety net: always remove from the players map, even if
+            // destroy() threw partway through and never reached the
+            // internal `this.riffy.players.delete(guildId)` line.
+            this.riffy.players.delete(guildId);
+        }
+
+        // Remove from persisted state so it isn't retried on every restart.
+        if (this._state.players[guildId]) {
+            delete this._state.players[guildId];
+            // Persist the cleanup (unless clearOnRestore will handle it).
+            if (!this.clearOnRestore) this.save(true);
+        }
+
+        this.riffy.emit("debug", `[ResumeManager] Restore FAILED for guild ${guildId}: reason="${reason}", detail="${detail}". Player destroyed, state removed.`);
+
+        /**
+         * @event playerRestoreFailed
+         * Emitted when a player could not be restored after a client restart.
+         * @param {string} guildId
+         * @param {string} reason One of: "timeout" | "socket_closed" | "no_nodes" | "invalid_state" | "error"
+         * @param {string} detail Human-readable detail.
+         * @param {any} state The persisted state that failed to restore.
+         */
+        this.riffy.emit("playerRestoreFailed", guildId, reason, detail, state);
+    }
+
+    /**
+     * Wait for voice credentials then send the track + seek position to the node.
+     * @private
+     */
+    async _sendResumePayload(player, state) {
+        try {
+            await player.connection.resolve();
+        } catch (e) {
+            this.riffy.emit("debug", `[ResumeManager] Voice connection not ready for ${player.guildId}; attempting payload anyway: ${e.message}`);
+        }
+
+        const encoded = state.current?.encoded || player.current?.track || player.current?.encoded;
+        if (!encoded) {
+            this.riffy.emit("debug", `[ResumeManager] No encoded track to resume for ${player.guildId}`);
+            return;
+        }
+
+        await player.node.rest.updatePlayer({
+            guildId: player.guildId,
+            data: {
+                track: { encoded },
+                position: state.position || 0,
+                volume: state.volume ?? player.volume,
+                paused: state.paused ?? false,
+            },
+        });
+
+        player.playing = !(state.paused ?? false);
+        player.paused = state.paused ?? false;
+        player.position = state.position || 0;
+
+        this.riffy.emit("playerResumed", player);
+    }
+
+    /**
+     * Attach event listeners to automatically persist state on player changes.
+     */
+    attachListeners() {
+        if (!this.enabled || this._listenersAttached) return;
+        this._listenersAttached = true;
+
+        const riffy = this.riffy;
+
+        riffy.on("trackStart", (player) => this.savePlayer(player));
+        riffy.on("trackEnd", (player) => this.savePlayer(player));
+        riffy.on("queueEnd", (player) => this.savePlayer(player));
+        riffy.on("playerCreate", (player) => this.savePlayer(player));
+        riffy.on("playerMove", (player) => this.savePlayer(player));
+        riffy.on("playerDestroy", (player) => this.removePlayer(player.guildId));
+
+        // playerUpdate fires frequently (~every 5s) from Lavalink with the
+        // current position. Throttled via saveInterval.
+        riffy.on("playerUpdate", (player) => this.savePlayer(player));
+
+        // Best-effort final flush on process exit (sync write).
+        const safeFlush = () => {
+            try {
+                this._flush();
+            } catch (_) {
+                /* ignore */
+            }
+        };
+        process.on("exit", safeFlush);
+        process.on("SIGINT", () => {
+            safeFlush();
+            process.exit(0);
+        });
+        process.on("SIGTERM", () => {
+            safeFlush();
+            process.exit(0);
+        });
+    }
+
+    /**
+     * Clear all persisted state — both in-memory and the on-disk file.
+     * Useful for testing or a manual reset.
+     */
+    clear() {
+        this._state = { version: 1, savedAt: 0, players: {} };
+        this._dirty = false;
+        if (this._saveTimer) { clearTimeout(this._saveTimer); this._saveTimer = null; }
+        this._clearDiskFile();
+    }
+
+    /**
+     * Get a read-only snapshot of the current persisted state.
+     */
+    get snapshot() {
+        return JSON.parse(JSON.stringify(this._state));
+    }
+}
+
+module.exports = { ResumeManager };

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -543,12 +543,20 @@ class ResumeManager {
             if (typeof state.volume === "number") player.volume = state.volume;
             if (state.loop) player.loop = state.loop;
 
-            // 3. Rebuild the queue. Bail out if aborted mid-rebuild.
+            // 3. Rebuild the queue. Use a bounded-concurrency batch pattern so
+            // an async requesterResolver (e.g. client.users.fetch) doesn't
+            // serialize N network calls. Aborts are checked between batches.
             if (Array.isArray(state.queue) && !isAborted()) {
-                for (const t of state.queue) {
-                    const rebuilt = await this._rebuildTrack(t, node, guildId);
-                    if (rebuilt) player.queue.add(rebuilt);
+                const BATCH_SIZE = 10;
+                for (let i = 0; i < state.queue.length; i += BATCH_SIZE) {
                     if (isAborted()) break;
+                    const batch = state.queue.slice(i, i + BATCH_SIZE);
+                    const rebuiltTracks = await Promise.all(
+                        batch.map((t) => isAborted() ? null : this._rebuildTrack(t, node, guildId))
+                    );
+                    for (const rebuilt of rebuiltTracks) {
+                        if (rebuilt) player.queue.add(rebuilt);
+                    }
                 }
             }
 
@@ -619,6 +627,15 @@ class ResumeManager {
                 }
             }
         };
+        // Bump the maxListeners limit before adding a concurrent socketClosed
+        // listener. With restoreConcurrency=8 (default), up to 8 listeners are
+        // registered simultaneously. Node's default EventEmitter limit is 10,
+        // so any bot with other socketClosed listeners would hit
+        // MaxListenersExceededWarning. We restore the limit in the finally block.
+        const prevMaxListeners = this.riffy.getMaxListeners();
+        if (prevMaxListeners !== 0) { // 0 = unlimited, no need to bump
+            this.riffy.setMaxListeners(prevMaxListeners + 1);
+        }
         this.riffy.on("socketClosed", socketClosedHandler);
 
         try {
@@ -633,6 +650,10 @@ class ResumeManager {
             clearTimeout(settleTimer);
             this._pendingRestores.delete(guildId);
             if (socketClosedHandler) this.riffy.off("socketClosed", socketClosedHandler);
+            // Restore the maxListeners limit we bumped above.
+            if (prevMaxListeners !== 0) {
+                this.riffy.setMaxListeners(Math.max(0, this.riffy.getMaxListeners() - 1));
+            }
         }
     }
 
@@ -904,6 +925,13 @@ class ResumeManager {
         const onQueueEnd = (player) => this.savePlayer(player);
         const onPlayerCreate = (player) => this.savePlayer(player);
         const onPlayerMove = (player) => this.savePlayer(player);
+        // Hook playerDisconnect (emitted by Player.destroy()) instead of just
+        // playerDestroy (only emitted by Riffy.destroyPlayer()). If a user or
+        // internal code calls player.destroy() directly, playerDisconnect
+        // still fires, so we clean up persisted state. Without this, a
+        // directly-destroyed player's state stays in the store and gets
+        // re-restored on the next restart — resurrecting a killed player.
+        const onPlayerDisconnect = (player) => this.removePlayer(player.guildId);
         const onPlayerDestroy = (player) => this.removePlayer(player.guildId);
         const onPlayerUpdate = (player) => this.savePlayer(player);
 
@@ -912,14 +940,15 @@ class ResumeManager {
         riffy.on("queueEnd", onQueueEnd);
         riffy.on("playerCreate", onPlayerCreate);
         riffy.on("playerMove", onPlayerMove);
+        riffy.on("playerDisconnect", onPlayerDisconnect);
         riffy.on("playerDestroy", onPlayerDestroy);
         riffy.on("playerUpdate", onPlayerUpdate);
 
         this._riffyHandlers = [
             ["trackStart", onTrackStart], ["trackEnd", onTrackEnd],
             ["queueEnd", onQueueEnd], ["playerCreate", onPlayerCreate],
-            ["playerMove", onPlayerMove], ["playerDestroy", onPlayerDestroy],
-            ["playerUpdate", onPlayerUpdate],
+            ["playerMove", onPlayerMove], ["playerDisconnect", onPlayerDisconnect],
+            ["playerDestroy", onPlayerDestroy], ["playerUpdate", onPlayerUpdate],
         ];
 
         // Best-effort final flush on process exit. Sync saveSync() is used

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -502,11 +502,15 @@ class ResumeManager {
                     // AFTER a timeout/socketClosed already aborted the restore.
                     await this._sendResumePayload(player, state, isAborted);
                 } else if (!isAborted() && player.queue.length > 0) {
-                    try {
-                        await player.play();
-                    } catch (e) {
-                        this.riffy.emit("debug", `[ResumeManager] Auto-play after restore failed for ${guildId}: ${e.message}`);
-                    }
+                    // No current track but queue has items — start playback.
+                    // If this fails (e.g. voice init failed, track unresolvable),
+                    // the error MUST propagate so restorePlayer's catch block
+                    // calls _failRestore → destroys the player, removes it from
+                    // state, and emits playerRestoreFailed. Previously this catch
+                    // swallowed the error, leaving an unusable player registered
+                    // with no failure event (review: "Queue restore reports
+                    // false success").
+                    await player.play();
                 }
 
                 // If the restore was aborted while we were waiting, do NOT
@@ -664,7 +668,17 @@ class ResumeManager {
      * _failRestore also now awaits player.destroy() so the DELETE is
      * ordered relative to the PATCH.
      *
+     * RACE FIX 3 (replacement player): the orphan-cleanup DELETE is
+     * guild-scoped, but by the time it fires, _failRestore has already
+     * emitted playerRestoreFailed. If the user's handler created a
+     * REPLACEMENT player for the same guild, this.players.get(guildId)
+     * now points at a DIFFERENT instance. A blind guild-scoped DELETE
+     * would kill the replacement's Lavalink session. So we only send the
+     * orphan-cleanup DELETE if the player instance we PATCHed is still
+     * the one registered for that guild (i.e. no replacement exists).
+     *
      * @private
+     * @param {import("./Player").Player} player The player being resumed (captured by ref).
      * @param {() => boolean} [isAborted] Returns true if the restore was aborted.
      */
     async _sendResumePayload(player, state, isAborted = () => false) {
@@ -697,19 +711,30 @@ class ResumeManager {
             },
         });
 
-        // RACE FIX 2: if aborted DURING the PATCH, the PATCH may have landed
-        // on Lavalink AFTER _failRestore's DELETE, recreating an orphan
-        // Lavalink player. Send a DELETE to clean it up. _failRestore has
-        // already destroyed the local player + emitted playerRestoreFailed;
-        // we just need to ensure Lavalink's side is also gone.
+        // RACE FIX 2 + 3: if aborted DURING/AFTER the PATCH, the PATCH may
+        // have landed on Lavalink AFTER _failRestore's DELETE, recreating an
+        // orphan Lavalink player. Send a DELETE to clean it up — BUT only if
+        // the player instance we PATCHed is still the one registered for
+        // this guild. If _failRestore emitted playerRestoreFailed and the
+        // user's handler created a REPLACEMENT player, this.players.get()
+        // now points at a different instance; a guild-scoped DELETE would
+        // kill the replacement's Lavalink session (review: "replacement
+        // player's Lavalink session silently stopped").
         if (isAborted()) {
-            this.riffy.emit("debug", `[ResumeManager] Restore aborted during/after PATCH for ${player.guildId}; sending DELETE to clean up orphan Lavalink player.`);
-            try {
-                await player.node.rest.destroyPlayer(player.guildId);
-            } catch (e) {
-                // Best-effort — the orphan cleanup is a safety net; if the
-                // DELETE fails (e.g. player already gone), that's fine.
-                this.riffy.emit("debug", `[ResumeManager] Orphan-cleanup DELETE failed for ${player.guildId}: ${e.message}`);
+            const currentPlayer = this.riffy.players.get(player.guildId);
+            if (currentPlayer === player) {
+                // No replacement — safe to delete the orphan we may have
+                // just recreated on Lavalink.
+                this.riffy.emit("debug", `[ResumeManager] Restore aborted during/after PATCH for ${player.guildId}; sending DELETE to clean up orphan Lavalink player.`);
+                try {
+                    await player.node.rest.destroyPlayer(player.guildId);
+                } catch (e) {
+                    this.riffy.emit("debug", `[ResumeManager] Orphan-cleanup DELETE failed for ${player.guildId}: ${e.message}`);
+                }
+            } else {
+                // A replacement player exists for this guild — do NOT send
+                // a guild-scoped DELETE, it would kill the replacement.
+                this.riffy.emit("debug", `[ResumeManager] Restore aborted after PATCH for ${player.guildId}, but a replacement player is now registered; skipping orphan-cleanup DELETE to avoid killing the replacement's Lavalink session.`);
             }
             return;
         }

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -66,6 +66,16 @@ class ResumeManager {
          * @since 1.0.15
          */
         this.maxQueueSize = options.maxQueueSize ?? null;
+        /**
+         * Max number of players to restore in parallel. Each restorePlayer
+         * involves a per-guild voice handshake that can take up to
+         * restoreTimeout. Restoring sequentially would stack these windows
+         * (50 guilds × 15s = 12.5 min worst case). Bounded concurrency keeps
+         * restores parallel without overwhelming the Discord gateway.
+         * Default: 8.
+         * @since 1.0.15
+         */
+        this.restoreConcurrency = typeof options.restoreConcurrency === "number" ? options.restoreConcurrency : 8;
 
         /** @type {{ version: number, savedAt: number, players: Record<string, any> }} */
         this._state = { version: 1, savedAt: 0, players: {} };
@@ -76,7 +86,7 @@ class ResumeManager {
         this._pendingRestores = new Map();
         /** @type {Map<string, NodeJS.Timeout>} guildId -> per-guild debounce timer */
         this._saveTimers = new Map();
-        /** @type {Promise<Map<string, any>> | null} */
+        /** @type {Promise<boolean> | null} load() promise (in-flight or null). */
         this._loadPromise = null;
 
         /** @type {StorageAdapter} */
@@ -369,7 +379,14 @@ class ResumeManager {
      */
     async restoreAll() {
         if (!this.enabled) return [];
-        if (this._restored) return [];
+        // Guard: restoreAll is idempotent — once it has run (even partially),
+        // it won't run again unless load() is called to reload state. This
+        // prevents duplicate restores if init()'s nodeConnect handler fires
+        // multiple times or resumePlayers() is called manually after init.
+        if (this._restored) {
+            this.riffy.emit("debug", `[ResumeManager] restoreAll() already ran, skipping (call load() to reload state first).`);
+            return [];
+        }
         this._restored = true;
 
         // Await any pending load (the adapter may still be reading).
@@ -384,19 +401,35 @@ class ResumeManager {
             return [];
         }
 
-        this.riffy.emit("debug", `[ResumeManager] Restoring ${guildIds.length} player(s)...`);
+        this.riffy.emit("debug", `[ResumeManager] Restoring ${guildIds.length} player(s) (concurrency=${this.restoreConcurrency})...`);
         const restored = [];
 
-        for (const guildId of guildIds) {
-            const state = this._state.players[guildId];
-            try {
-                const player = await this.restorePlayer(state);
-                if (player) restored.push(player);
-            } catch (e) {
-                this.riffy.emit("debug", `[ResumeManager] Failed to restore player ${guildId}: ${e.message}`);
-                delete this._state.players[guildId];
+        // Restore players concurrently with a bounded concurrency limit so a
+        // bot in 50+ guilds doesn't restore sequentially (each restoreTimeout
+        // window would otherwise stack: 50 × 15s = 12.5 min worst case).
+        // Each restorePlayer is independent (per-guild voice handshakes), so
+        // they can run in parallel safely.
+        const concurrency = Math.max(1, this.restoreConcurrency);
+        const queue = [...guildIds];
+        const workers = [];
+        const worker = async () => {
+            while (queue.length > 0) {
+                const guildId = queue.shift();
+                const state = this._state.players[guildId];
+                if (!state) continue;
+                try {
+                    const player = await this.restorePlayer(state);
+                    if (player) restored.push(player);
+                } catch (e) {
+                    this.riffy.emit("debug", `[ResumeManager] Failed to restore player ${guildId}: ${e.message}`);
+                    delete this._state.players[guildId];
+                }
             }
+        };
+        for (let i = 0; i < Math.min(concurrency, guildIds.length); i++) {
+            workers.push(worker());
         }
+        await Promise.allSettled(workers);
 
         this.riffy.emit("debug", `[ResumeManager] Restore complete (${restored.length}/${guildIds.length} succeeded).`);
 
@@ -610,7 +643,9 @@ class ResumeManager {
                 this.riffy.emit("debug", `[ResumeManager] destroyPlayer DELETE failed for ${guildId}: ${e.message}`);
             }
             try {
-                player.destroy();
+                // skipRest=true: we already sent the DELETE above, so don't
+                // let player.destroy() fire a second (unawaited) one.
+                player.destroy(true);
             } catch (e) {
                 this.riffy.emit("debug", `[ResumeManager] Error destroying failed player for ${guildId}: ${e.message}`);
             }
@@ -775,15 +810,24 @@ class ResumeManager {
         // current position. Throttled via saveInterval (per-guild).
         riffy.on("playerUpdate", (player) => this.savePlayer(player));
 
-        // Best-effort final flush on process exit. Flushes all pending
-        // per-guild debounced writes synchronously (the adapters use sync fs
-        // writes under the hood, so this works on the exit tick).
+        // Best-effort final flush on process exit. Async I/O on process exit
+        // is unreliable (the event loop is torn down), so we prefer a sync
+        // saveSync() method if the adapter provides one (JsonFileStorage and
+        // ShardedJsonStorage do). For adapters that only have async save()
+        // (SqliteStorage, custom Redis/Postgres), we call it anyway as a last
+        // resort — it may not complete, but it's better than nothing.
         const safeFlush = () => {
             try {
                 for (const [guildId, timer] of this._saveTimers) {
                     clearTimeout(timer);
                     const state = this._state.players[guildId];
-                    if (state) this.storage.save(guildId, state).catch(() => {});
+                    if (state) {
+                        if (typeof this.storage.saveSync === "function") {
+                            this.storage.saveSync(guildId, state);
+                        } else {
+                            this.storage.save(guildId, state).catch(() => {});
+                        }
+                    }
                 }
                 this._saveTimers.clear();
             } catch (_) {

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -561,7 +561,13 @@ class ResumeManager {
             }
 
             // 4. Restore current track + seek to the saved position.
-            if (!isAborted() && state.current && (state.current.encoded || (state.current.info && state.current.info.identifier))) {
+            // Only enter this path when we have an encoded track string —
+            // the Lavalink seek PATCH requires it. A saved state with only
+            // info.identifier (no encoded) cannot be resumed via Lavalink,
+            // so we fall through to the queue-only path instead. This
+            // prevents false success where playerResumed fires but no audio
+            // plays (bot sits in voice channel with nothing loaded).
+            if (!isAborted() && state.current && state.current.encoded) {
                 const currentTrack = await this._rebuildTrack(state.current, node, guildId);
                 player.current = currentTrack;
                 player.position = state.position || 0;
@@ -578,6 +584,14 @@ class ResumeManager {
                 // _failRestore → destroys the player, removes it from state,
                 // and emits playerRestoreFailed.
                 await player.play();
+            } else {
+                // No encoded current track AND empty queue — the player was
+                // created but has nothing to play. This is an idle restore:
+                // the bot rejoined the voice channel but won't produce audio.
+                // Do NOT emit playerResumed (false success) — return null so
+                // restoreAll doesn't count it as a successful restore.
+                this.riffy.emit("debug", `[ResumeManager] Restored player for guild ${guildId} is idle (no current track, empty queue) — not emitting playerResumed.`);
+                return null;
             }
 
             // If the restore was aborted while we were waiting, do NOT

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -785,6 +785,33 @@ class ResumeManager {
                 } catch (e) {
                     this.riffy.emit("debug", `[ResumeManager] Orphan-cleanup DELETE failed for ${player.guildId}: ${e.message}`);
                 }
+                // RACE FIX 4: a replacement player may have been created and
+                // established its Lavalink session WHILE the DELETE was in flight
+                // (the user's async playerRestoreFailed handler runs after
+                // _failRestore emits the event, and createConnection →
+                // updatePlayer can land before this DELETE completes). The
+                // guild-scoped DELETE just killed the replacement's Lavalink
+                // session. Re-send the replacement's current track to restore it.
+                const afterDelete = this.riffy.players.get(player.guildId);
+                if (afterDelete && afterDelete !== player && afterDelete.current) {
+                    this.riffy.emit("debug", `[ResumeManager] Replacement player detected after orphan-cleanup DELETE for ${player.guildId}; re-sending its track to restore the Lavalink session.`);
+                    try {
+                        const replEncoded = afterDelete.current.track || afterDelete.current.encoded;
+                        if (replEncoded) {
+                            await afterDelete.node.rest.updatePlayer({
+                                guildId: player.guildId,
+                                data: {
+                                    track: { encoded: replEncoded },
+                                    position: afterDelete.position || 0,
+                                    volume: afterDelete.volume,
+                                    paused: afterDelete.paused,
+                                },
+                            });
+                        }
+                    } catch (e) {
+                        this.riffy.emit("debug", `[ResumeManager] Re-PATCH of replacement failed for ${player.guildId}: ${e.message}`);
+                    }
+                }
             } else {
                 // A replacement player exists for this guild — do NOT send
                 // a guild-scoped DELETE, it would kill the replacement's

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -1,14 +1,18 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { Track } = require("./Track");
+const { StorageAdapter } = require("./storage/StorageAdapter");
+const { JsonFileStorage } = require("./storage/JsonFileStorage");
+const { ShardedJsonStorage } = require("./storage/ShardedJsonStorage");
+const { SqliteStorage } = require("./storage/SqliteStorage");
 
 /**
  * ResumeManager
  *
  * Provides client-restart auto-resume for Riffy. Persists player state
  * (voice channel, text channel, current track, playback position, volume,
- * loop mode, paused state, and the full queue) to a JSON file on disk and
- * restores all players after the bot process restarts.
+ * loop mode, paused state, and the full queue) to a pluggable storage
+ * adapter and restores all players after the bot process restarts.
  *
  * On restore it will:
  *   1. Re-create the player connection (rejoin the same voice channel).
@@ -19,15 +23,32 @@ const { Track } = require("./Track");
  * This is distinct from Node-level `autoResume` (which only re-establishes
  * players when the Lavalink WebSocket reconnects). ResumeManager survives a
  * full process restart.
+ *
+ * ## Scaling
+ *
+ * The storage backend is swappable via `options.storage`. Built-in adapters:
+ *   - `"json"` / `{ type: "json", filePath }` — single file (default; <~100 players)
+ *   - `"sharded"` / `{ type: "sharded", dir }` — one file per guild (thousands)
+ *   - `"sqlite"` / `{ type: "sqlite", path }` — indexed DB (tens of thousands)
+ *   - or pass any custom `StorageAdapter` instance (Redis, Postgres, Mongo…)
+ *
+ * If omitted, defaults to `JsonFileStorage` using `filePath` (backward compat).
+ *
+ * Per-guild writes are debounced independently — a busy guild never blocks
+ * writes for other guilds.
  */
 class ResumeManager {
     /**
      * @param {import("./Riffy").Riffy} riffy
      * @param {Object} [options]
      * @param {boolean} [options.enabled=false] Enable client-restart resume.
-     * @param {string} [options.filePath] Path to the state JSON file. Defaults to `<cwd>/riffy-state.json`.
-     * @param {number} [options.saveInterval=3000] Debounce window (ms) for disk writes.
+     * @param {string} [options.filePath] Path to the JSON file (JsonFileStorage) or directory (ShardedJsonStorage).
+     * @param {number} [options.saveInterval=3000] Debounce window (ms) for per-guild disk writes.
      * @param {(requester: any) => any} [options.requesterResolver] Optional function to rebuild a requester object from the persisted value.
+     * @param {boolean} [options.clearOnRestore=false] Delete persisted state after a successful full restore.
+     * @param {number} [options.restoreTimeout=15000] Max ms to wait for voice credentials per player before aborting.
+     * @param {number|null} [options.maxQueueSize=null] Cap how many queue tracks to persist per guild (prevents a single huge playlist from bloating storage). `null` = no limit.
+     * @param {string|object|StorageAdapter} [options.storage] Storage adapter: preset string ("json"|"sharded"|"sqlite"), a config object ({type, ...}), or a custom adapter instance.
      */
     constructor(riffy, options = {}) {
         this.riffy = riffy;
@@ -35,91 +56,99 @@ class ResumeManager {
         this.filePath = options.filePath || path.join(process.cwd(), "riffy-state.json");
         this.saveInterval = typeof options.saveInterval === "number" ? options.saveInterval : 3000;
         this.requesterResolver = typeof options.requesterResolver === "function" ? options.requesterResolver : null;
-        /**
-         * When `true`, the persisted state file is deleted from disk once a
-         * full restore completes successfully. This prevents stale state from
-         * accumulating and being re-applied on every subsequent restart.
-         *
-         * The in-memory state is also wiped, so a second restoreAll() call
-         * becomes a no-op (returns `[]`). New player activity after the
-         * restore will be persisted fresh as usual.
-         *
-         * Default: `false` (state is kept across restarts).
-         */
         this.clearOnRestore = options.clearOnRestore ?? false;
-        /**
-         * Maximum time (ms) to wait for voice credentials when restoring a
-         * single player. If Discord doesn't reply with a VOICE_SERVER_UPDATE
-         * in time (e.g. the voice channel was deleted, the bot was kicked,
-         * or it lacks Connect permission), the restore for that guild is
-         * aborted, the half-created player is destroyed, the guild is
-         * removed from persisted state, and a `playerRestoreFailed` event
-         * is emitted with reason `"timeout"`.
-         *
-         * Default: `15000` (15 seconds).
-         */
         this.restoreTimeout = typeof options.restoreTimeout === "number" ? options.restoreTimeout : 15000;
+        /**
+         * Max number of queue tracks to persist per guild. A bot in a guild
+         * where someone queued a 500-track playlist would otherwise bloat
+         * storage; capping prevents that. `null` = no limit.
+         * Default: `null` (no limit).
+         * @since 1.0.15
+         */
+        this.maxQueueSize = options.maxQueueSize ?? null;
 
         /** @type {{ version: number, savedAt: number, players: Record<string, any> }} */
         this._state = { version: 1, savedAt: 0, players: {} };
-        this._saveTimer = null;
-        this._dirty = false;
         this._restored = false;
         this._restoredFully = false;
         this._listenersAttached = false;
         /** @type {Map<string, (reason: string, detail?: any) => void>} guildId -> reject fn for active restores */
         this._pendingRestores = new Map();
+        /** @type {Map<string, NodeJS.Timeout>} guildId -> per-guild debounce timer */
+        this._saveTimers = new Map();
+        /** @type {Promise<Map<string, any>> | null} */
+        this._loadPromise = null;
+
+        /** @type {StorageAdapter} */
+        this.storage = this._resolveStorage(options);
     }
 
     /**
-     * Load persisted state from disk into memory. Corrupt or partial writes
-     * (e.g. from a crash mid-flush or storage loss) are handled gracefully:
-     * if the file can't be parsed, or individual player entries are missing
-     * required fields, those entries are dropped and logged rather than
-     * crashing the restore.
-     * @returns {boolean} Whether any valid players were loaded.
+     * Resolve the storage adapter from the `storage` option, falling back to
+     * JsonFileStorage for backward compatibility.
+     * @private
+     */
+    _resolveStorage(options) {
+        const s = options.storage;
+        // 1. Custom adapter instance — use as-is.
+        if (s && typeof s === "object" && typeof s.save === "function" && typeof s.loadAll === "function") {
+            return s;
+        }
+        // 2. Config object: { type: "json"|"sharded"|"sqlite", ... }
+        if (s && typeof s === "object" && typeof s.type === "string") {
+            if (s.type === "json") return new JsonFileStorage({ filePath: s.filePath || options.filePath }, this.riffy);
+            if (s.type === "sharded") return new ShardedJsonStorage({ dir: s.dir || options.filePath || path.join(process.cwd(), "riffy-state") }, this.riffy);
+            if (s.type === "sqlite") return new SqliteStorage({ path: s.path || options.filePath || "riffy-state.db" }, this.riffy);
+            throw new Error(`Unknown storage type: ${s.type}. Use "json", "sharded", "sqlite", or pass a custom StorageAdapter.`);
+        }
+        // 3. Preset string: "json" | "sharded" | "sqlite"
+        if (typeof s === "string") {
+            if (s === "json") return new JsonFileStorage({ filePath: options.filePath }, this.riffy);
+            if (s === "sharded") return new ShardedJsonStorage({ dir: options.filePath || path.join(process.cwd(), "riffy-state") }, this.riffy);
+            if (s === "sqlite") return new SqliteStorage({ path: options.filePath || "riffy-state.db" }, this.riffy);
+            throw new Error(`Unknown storage preset: ${s}. Use "json", "sharded", or "sqlite".`);
+        }
+        // 4. Default (backward compat): single JSON file via filePath.
+        return new JsonFileStorage({ filePath: options.filePath }, this.riffy);
+    }
+
+    /**
+     * Load persisted state from the storage adapter into memory. Async (the
+     * adapter may do real I/O). Returns a Promise that resolves to the loaded
+     * Map; callers that don't await can rely on restoreAll() to await it.
+     *
+     * Corrupt entries are dropped + logged by the adapter rather than crashing
+     * the restore. Validation is also applied here as a second line of defense.
+     *
+     * @returns {Promise<boolean>} Whether any valid players were loaded.
      */
     load() {
-        if (!this.enabled) return false;
-        try {
-            if (!fs.existsSync(this.filePath)) return false;
-            const raw = fs.readFileSync(this.filePath, "utf-8");
-            const parsed = JSON.parse(raw);
-            if (!parsed || typeof parsed !== "object" || !parsed.players) return false;
-
+        if (!this.enabled) return Promise.resolve(false);
+        this._loadPromise = (async () => {
+            await this.storage.init();
+            const loaded = await this.storage.loadAll();
             const validPlayers = {};
             let dropped = 0;
-            for (const [guildId, state] of Object.entries(parsed.players)) {
+            for (const [guildId, state] of loaded.entries()) {
                 const validation = this._validatePlayerState(guildId, state);
                 if (validation.ok) {
                     validPlayers[guildId] = state;
                 } else {
                     dropped++;
                     this.riffy.emit("debug", `[ResumeManager] Dropped invalid persisted entry for guild ${guildId}: ${validation.reason}`);
+                    // Remove the bad entry from the store so it isn't retried.
+                    this.storage.remove(guildId).catch(() => {});
                 }
             }
-
-            this._state = { version: 1, savedAt: parsed.savedAt || 0, players: validPlayers };
+            this._state = { version: 1, savedAt: Date.now(), players: validPlayers };
             const count = Object.keys(validPlayers).length;
-            this.riffy.emit("debug", `[ResumeManager] Loaded state for ${count} player(s) from ${this.filePath}${dropped ? ` (dropped ${dropped} invalid entry/entries)` : ""}`);
-
-            // If we dropped invalid entries, persist the cleaned-up state.
-            if (dropped > 0) this.save(true);
+            this.riffy.emit("debug", `[ResumeManager] Loaded state for ${count} player(s) via ${this.storage.constructor.name}${dropped ? ` (dropped ${dropped} invalid entry/entries)` : ""}`);
             return count > 0;
-        } catch (e) {
-            this.riffy.emit("debug", `[ResumeManager] Failed to load state from ${this.filePath} (likely corrupt or partial write): ${e.message}`);
-            // Move the corrupt file aside so future saves aren't blocked by it.
-            try {
-                if (fs.existsSync(this.filePath)) {
-                    const backup = this.filePath + ".corrupt-" + Date.now();
-                    fs.renameSync(this.filePath, backup);
-                    this.riffy.emit("debug", `[ResumeManager] Moved corrupt state file to ${backup}`);
-                }
-            } catch (_) {
-                /* ignore */
-            }
+        })().catch((e) => {
+            this.riffy.emit("debug", `[ResumeManager] load() failed: ${e.message}`);
             return false;
-        }
+        });
+        return this._loadPromise;
     }
 
     /**
@@ -142,35 +171,20 @@ class ResumeManager {
     }
 
     /**
-     * Schedule a debounced write to disk.
-     * @param {boolean} [immediate=false] If true, flush synchronously right now.
+     * Flush any pending per-guild debounced writes immediately. Returns a
+     * Promise that resolves when all pending saves have settled.
+     * @returns {Promise<void>}
      */
-    save(immediate = false) {
+    async save() {
         if (!this.enabled) return;
-        this._dirty = true;
-        if (immediate) {
-            this._flush();
-            return;
-        }
-        if (this._saveTimer) return;
-        this._saveTimer = setTimeout(() => {
-            this._saveTimer = null;
-            this._flush();
-        }, this.saveInterval);
-    }
-
-    /** @private */
-    _flush() {
-        if (!this._dirty) return;
-        this._dirty = false;
-        try {
-            this._state.savedAt = Date.now();
-            const dir = path.dirname(this.filePath);
-            if (dir && !fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-            fs.writeFileSync(this.filePath, JSON.stringify(this._state, null, 2), "utf-8");
-        } catch (e) {
-            this.riffy.emit("debug", `[ResumeManager] Failed to save state to ${this.filePath}: ${e.message}`);
-        }
+        const guildIds = [...this._saveTimers.keys()];
+        await Promise.allSettled(guildIds.map((guildId) => {
+            const timer = this._saveTimers.get(guildId);
+            if (timer) { clearTimeout(timer); this._saveTimers.delete(guildId); }
+            const state = this._state.players[guildId];
+            if (state) return this.storage.save(guildId, state);
+            return this.storage.remove(guildId);
+        }));
     }
 
     /**
@@ -218,7 +232,10 @@ class ResumeManager {
     }
 
     /**
-     * Serialize a player into a JSON-safe object.
+     * Serialize a player into a JSON-safe object. If `maxQueueSize` is set,
+     * the queue is truncated to that many tracks (keeping the first N, which
+     * are the soonest-to-play) to prevent a single huge playlist from
+     * bloating storage.
      * @param {import("./Player").Player} player
      */
     serializePlayer(player) {
@@ -232,11 +249,15 @@ class ResumeManager {
               }
             : null;
 
-        const queue = (player.queue || []).map((t) => ({
+        let queue = (player.queue || []).map((t) => ({
             encoded: t.track || t.encoded || null,
             info: this._safeSerializeInfo(t.info),
             pluginInfo: t.pluginInfo || null,
         }));
+        // Cap queue size to bound per-guild storage.
+        if (this.maxQueueSize !== null && queue.length > this.maxQueueSize) {
+            queue = queue.slice(0, this.maxQueueSize);
+        }
 
         return {
             guildId: player.guildId,
@@ -256,7 +277,9 @@ class ResumeManager {
     }
 
     /**
-     * Update stored state for a single player and schedule a save.
+     * Update stored state for a single player and schedule a per-guild
+     * debounced write. Each guild has its own timer, so a busy guild never
+     * delays writes for other guilds.
      * @param {import("./Player").Player} player
      */
     savePlayer(player) {
@@ -264,18 +287,38 @@ class ResumeManager {
         const serialized = this.serializePlayer(player);
         if (!serialized) return;
         this._state.players[player.guildId] = serialized;
-        this.save();
+        // Per-guild debounce.
+        if (this._saveTimers.has(player.guildId)) {
+            clearTimeout(this._saveTimers.get(player.guildId));
+        }
+        this._saveTimers.set(player.guildId, setTimeout(() => {
+            this._saveTimers.delete(player.guildId);
+            const state = this._state.players[player.guildId];
+            if (state) {
+                this.storage.save(player.guildId, state).catch((err) => {
+                    this.riffy.emit("debug", `[ResumeManager] storage.save failed for ${player.guildId}: ${err.message}`);
+                });
+            }
+        }, this.saveInterval));
     }
 
     /**
-     * Remove a player from persisted state (e.g. when destroyed).
+     * Remove a player from persisted state immediately (no debounce —
+     * destroys should be instant so the guild isn't restored next restart).
      * @param {string} guildId
      */
     removePlayer(guildId) {
         if (!this.enabled) return;
+        // Cancel any pending save for this guild.
+        if (this._saveTimers.has(guildId)) {
+            clearTimeout(this._saveTimers.get(guildId));
+            this._saveTimers.delete(guildId);
+        }
         if (this._state.players[guildId]) {
             delete this._state.players[guildId];
-            this.save();
+            this.storage.remove(guildId).catch((err) => {
+                this.riffy.emit("debug", `[ResumeManager] storage.remove failed for ${guildId}: ${err.message}`);
+            });
         }
     }
 
@@ -319,11 +362,15 @@ class ResumeManager {
         if (this._restored) return [];
         this._restored = true;
 
+        // Await any pending load (the adapter may still be reading).
+        if (this._loadPromise) {
+            try { await this._loadPromise; } catch (_) { /* already logged */ }
+        }
+
         const guildIds = Object.keys(this._state.players || {});
         if (!guildIds.length) {
             this.riffy.emit("debug", `[ResumeManager] No saved players to restore.`);
-            // Still honor clearOnRestore so a leftover empty/stale file is removed.
-            if (this.clearOnRestore) this._clearDiskFile();
+            if (this.clearOnRestore) { await this.storage.clear().catch(() => {}); }
             return [];
         }
 
@@ -344,35 +391,17 @@ class ResumeManager {
         this.riffy.emit("debug", `[ResumeManager] Restore complete (${restored.length}/${guildIds.length} succeeded).`);
 
         if (this.clearOnRestore) {
-            // Wipe in-memory state and delete the on-disk file so it isn't
-            // re-applied on the next restart. Fresh state will be written as
-            // new player activity happens.
+            // Wipe in-memory state and clear the store so it isn't re-applied
+            // on the next restart. Fresh state is written as new activity happens.
             this._state = { version: 1, savedAt: 0, players: {} };
-            this._dirty = false;
-            if (this._saveTimer) { clearTimeout(this._saveTimer); this._saveTimer = null; }
-            this._clearDiskFile();
+            for (const t of this._saveTimers.values()) clearTimeout(t);
+            this._saveTimers.clear();
+            await this.storage.clear().catch(() => {});
             this._restoredFully = true;
-            this.riffy.emit("debug", `[ResumeManager] clearOnRestore enabled — state file removed, in-memory state wiped.`);
-        } else {
-            this.save(true);
+            this.riffy.emit("debug", `[ResumeManager] clearOnRestore enabled — store cleared, in-memory state wiped.`);
         }
 
         return restored;
-    }
-
-    /**
-     * Delete the persisted state file from disk (if it exists).
-     * @private
-     */
-    _clearDiskFile() {
-        try {
-            if (fs.existsSync(this.filePath)) {
-                fs.unlinkSync(this.filePath);
-                this.riffy.emit("debug", `[ResumeManager] Deleted state file: ${this.filePath}`);
-            }
-        } catch (e) {
-            this.riffy.emit("debug", `[ResumeManager] Failed to delete state file ${this.filePath}: ${e.message}`);
-        }
     }
 
     /**
@@ -532,8 +561,12 @@ class ResumeManager {
         // Remove from persisted state so it isn't retried on every restart.
         if (this._state.players[guildId]) {
             delete this._state.players[guildId];
-            // Persist the cleanup (unless clearOnRestore will handle it).
-            if (!this.clearOnRestore) this.save(true);
+            // Persist the cleanup immediately (unless clearOnRestore will wipe all).
+            if (!this.clearOnRestore) {
+                this.storage.remove(guildId).catch((err) => {
+                    this.riffy.emit("debug", `[ResumeManager] storage.remove failed for ${guildId} after failed restore: ${err.message}`);
+                });
+            }
         }
 
         this.riffy.emit("debug", `[ResumeManager] Restore FAILED for guild ${guildId}: reason="${reason}", detail="${detail}". Player destroyed, state removed.`);
@@ -600,13 +633,20 @@ class ResumeManager {
         riffy.on("playerDestroy", (player) => this.removePlayer(player.guildId));
 
         // playerUpdate fires frequently (~every 5s) from Lavalink with the
-        // current position. Throttled via saveInterval.
+        // current position. Throttled via saveInterval (per-guild).
         riffy.on("playerUpdate", (player) => this.savePlayer(player));
 
-        // Best-effort final flush on process exit (sync write).
+        // Best-effort final flush on process exit. Flushes all pending
+        // per-guild debounced writes synchronously (the adapters use sync fs
+        // writes under the hood, so this works on the exit tick).
         const safeFlush = () => {
             try {
-                this._flush();
+                for (const [guildId, timer] of this._saveTimers) {
+                    clearTimeout(timer);
+                    const state = this._state.players[guildId];
+                    if (state) this.storage.save(guildId, state).catch(() => {});
+                }
+                this._saveTimers.clear();
             } catch (_) {
                 /* ignore */
             }
@@ -623,14 +663,14 @@ class ResumeManager {
     }
 
     /**
-     * Clear all persisted state — both in-memory and the on-disk file.
+     * Clear all persisted state — both in-memory and the backing store.
      * Useful for testing or a manual reset.
      */
-    clear() {
+    async clear() {
         this._state = { version: 1, savedAt: 0, players: {} };
-        this._dirty = false;
-        if (this._saveTimer) { clearTimeout(this._saveTimer); this._saveTimer = null; }
-        this._clearDiskFile();
+        for (const t of this._saveTimers.values()) clearTimeout(t);
+        this._saveTimers.clear();
+        await this.storage.clear().catch(() => {});
     }
 
     /**

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -449,9 +449,21 @@ class ResumeManager {
         // waiting the full restoreTimeout.
         let settleTimer = null;
         let socketClosedHandler = null;
+        // Abort flag: set by the reject function (timeout / socketClosed) so
+        // the async executor still running in _sendResumePayload can bail out
+        // instead of PATCHing Lavalink + emitting playerResumed AFTER the
+        // restore has already been treated as failed. Without this, a late
+        // VOICE_SERVER_UPDATE would let the executor resurrect a destroyed
+        // player (race condition flagged in review).
+        let aborted = false;
+        const isAborted = () => aborted;
         const restorePromise = new Promise(async (resolve, reject) => {
             // Register the reject so socketClosed / timeout can abort.
-            this._pendingRestores.set(guildId, (reason, detail) => reject({ reason, detail }));
+            // Setting `aborted = true` first ensures the executor checks it.
+            this._pendingRestores.set(guildId, (reason, detail) => {
+                aborted = true;
+                reject({ reason, detail });
+            });
 
             try {
                 // 1. Re-create the connection -> sends VOICE_STATE_UPDATE to rejoin.
@@ -469,29 +481,41 @@ class ResumeManager {
                 if (typeof state.volume === "number") player.volume = state.volume;
                 if (state.loop) player.loop = state.loop;
 
-                // 3. Rebuild the queue.
-                if (Array.isArray(state.queue)) {
+                // 3. Rebuild the queue. Bail out if aborted mid-rebuild.
+                if (Array.isArray(state.queue) && !isAborted()) {
                     for (const t of state.queue) {
                         const rebuilt = await this._rebuildTrack(t, node);
                         if (rebuilt) player.queue.add(rebuilt);
+                        if (isAborted()) break;
                     }
                 }
 
                 // 4. Restore current track + seek to the saved position.
-                if (state.current && (state.current.encoded || (state.current.info && state.current.info.identifier))) {
+                if (!isAborted() && state.current && (state.current.encoded || (state.current.info && state.current.info.identifier))) {
                     const currentTrack = await this._rebuildTrack(state.current, node);
                     player.current = currentTrack;
                     player.position = state.position || 0;
                     player.paused = state.paused ?? false;
 
                     // Send the resume payload once voice credentials arrive.
-                    await this._sendResumePayload(player, state);
-                } else if (player.queue.length > 0) {
+                    // Pass isAborted so it can bail out if voice creds arrive
+                    // AFTER a timeout/socketClosed already aborted the restore.
+                    await this._sendResumePayload(player, state, isAborted);
+                } else if (!isAborted() && player.queue.length > 0) {
                     try {
                         await player.play();
                     } catch (e) {
                         this.riffy.emit("debug", `[ResumeManager] Auto-play after restore failed for ${guildId}: ${e.message}`);
                     }
+                }
+
+                // If the restore was aborted while we were waiting, do NOT
+                // resolve — the promise has already been rejected, and the
+                // caller's catch block runs _failRestore. Resolving here would
+                // be a no-op (promise already settled), but we also must not
+                // emit the "Restored player" debug line.
+                if (isAborted()) {
+                    return;
                 }
 
                 this.riffy.emit(
@@ -500,7 +524,8 @@ class ResumeManager {
                 );
                 resolve(player);
             } catch (err) {
-                reject({ reason: "error", detail: err });
+                // If aborted, prefer the abort reason over this error.
+                if (!isAborted()) reject({ reason: "error", detail: err });
             }
         });
 
@@ -601,12 +626,29 @@ class ResumeManager {
      * We must NOT swallow it and proceed to PATCH the track + emit
      * playerResumed — that would treat a failed restore as successful.
      *
+     * RACE FIX: If the restore was aborted (timeout / socketClosed) WHILE
+     * we're awaiting connection.resolve(), the caller's _failRestore has
+     * already destroyed the player + emitted playerRestoreFailed. If voice
+     * creds then arrive, we must NOT PATCH Lavalink or emit playerResumed —
+     * that would resurrect a destroyed player. The `isAborted` callback is
+     * checked after the await and before the PATCH to bail out cleanly.
+     *
      * @private
+     * @param {() => boolean} [isAborted] Returns true if the restore was aborted.
      */
-    async _sendResumePayload(player, state) {
+    async _sendResumePayload(player, state, isAborted = () => false) {
         // This throws if Discord doesn't supply voice credentials. Let it
         // propagate so the restore is treated as a failure, not a success.
         await player.connection.resolve();
+
+        // RACE FIX: voice creds arrived, but the restore may have already
+        // been aborted (timeout / socketClosed) while we were waiting. If so,
+        // _failRestore has already destroyed the player + emitted
+        // playerRestoreFailed. Bail out — do NOT PATCH or emit playerResumed.
+        if (isAborted()) {
+            this.riffy.emit("debug", `[ResumeManager] Voice credentials arrived for ${player.guildId} but restore was already aborted; not patching/emitting.`);
+            return;
+        }
 
         const encoded = state.current?.encoded || player.current?.track || player.current?.encoded;
         if (!encoded) {
@@ -623,6 +665,13 @@ class ResumeManager {
                 paused: state.paused ?? false,
             },
         });
+
+        // Re-check after the PATCH too — if aborted during the PATCH request,
+        // don't flip state or emit playerResumed.
+        if (isAborted()) {
+            this.riffy.emit("debug", `[ResumeManager] Restore aborted during PATCH for ${player.guildId}; not emitting playerResumed.`);
+            return;
+        }
 
         player.playing = !(state.paused ?? false);
         player.paused = state.paused ?? false;

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -87,6 +87,10 @@ class ResumeManager {
         this._saveTimers = new Map();
         /** @type {Promise<boolean> | null} load() promise (in-flight or null). */
         this._loadPromise = null;
+        /** @private Stored process signal handler refs so clear()/destroy() can unregister them. */
+        this._processHandlers = null;
+        /** @private Stored riffy event handler refs so destroy() can unregister them. */
+        this._riffyHandlers = null;
 
         /** @type {StorageAdapter} */
         this.storage = this._resolveStorage(options);
@@ -179,6 +183,14 @@ class ResumeManager {
         if (state.paused !== undefined && typeof state.paused !== "boolean") return { ok: false, reason: "paused is not a boolean" };
         if (state.queue !== undefined && !Array.isArray(state.queue)) return { ok: false, reason: "queue is not an array" };
         if (state.current !== undefined && state.current !== null && typeof state.current !== "object") return { ok: false, reason: "current is not an object" };
+        if (state.current && state.current.encoded !== undefined && state.current.encoded !== null && typeof state.current.encoded !== "string") return { ok: false, reason: "current.encoded is not a string" };
+        if (state.queue) {
+            for (let i = 0; i < state.queue.length; i++) {
+                const t = state.queue[i];
+                if (!t || typeof t !== "object") return { ok: false, reason: `queue[${i}] is not an object` };
+                if (t.encoded !== undefined && t.encoded !== null && typeof t.encoded !== "string") return { ok: false, reason: `queue[${i}].encoded is not a string` };
+            }
+        }
         return { ok: true };
     }
 
@@ -344,8 +356,11 @@ class ResumeManager {
      * Reconstruct a Track object from serialized data. Async because the
      * requesterResolver may return a Promise (e.g. client.users.fetch(id)).
      * @private
+     * @param {any} data Serialized track data.
+     * @param {any} node The Lavalink node to pass to the Track constructor.
+     * @param {string} [guildId] The guild being restored (for debug logging).
      */
-    async _rebuildTrack(data, node) {
+    async _rebuildTrack(data, node, guildId) {
         if (!data) return null;
         const encoded = data.encoded || null;
         let requester = data.info?.requester ?? null;
@@ -362,7 +377,7 @@ class ResumeManager {
                 }
             } catch (e) {
                 // Resolver threw (e.g. user not found) — keep primitive requester.
-                this.riffy.emit("debug", `[ResumeManager] requesterResolver threw for guild: ${e.message}`);
+                this.riffy.emit("debug", `[ResumeManager] requesterResolver threw for guild ${guildId ?? "?"}: ${e.message}`);
             }
         }
         const track = new Track(
@@ -501,80 +516,82 @@ class ResumeManager {
         // player (race condition flagged in review).
         let aborted = false;
         const isAborted = () => aborted;
-        const restorePromise = new Promise(async (resolve, reject) => {
-            // Register the reject so socketClosed / timeout can abort.
-            // Setting `aborted = true` first ensures the executor checks it.
-            this._pendingRestores.set(guildId, (reason, detail) => {
-                aborted = true;
-                reject({ reason, detail });
+
+        // Register the reject fn BEFORE creating the Promise so timeout /
+        // socketClosed can abort it. This avoids the `new Promise(async ...)`
+        // anti-pattern where errors in the executor's setup (e.g. Map.set
+        // throwing) would be swallowed and the Promise would never settle.
+        const rejectRef = { fn: null };
+        this._pendingRestores.set(guildId, (reason, detail) => {
+            aborted = true;
+            if (rejectRef.fn) rejectRef.fn({ reason, detail });
+        });
+
+        const runRestore = async () => {
+            // 1. Re-create the connection -> sends VOICE_STATE_UPDATE to rejoin.
+            const player = this.riffy.createConnection({
+                guildId,
+                voiceChannel: state.voiceChannel,
+                textChannel: state.textChannel,
+                deaf: state.deaf ?? true,
+                mute: state.mute ?? false,
+                defaultVolume: state.volume ?? 100,
+                loop: state.loop ?? "none",
             });
 
-            try {
-                // 1. Re-create the connection -> sends VOICE_STATE_UPDATE to rejoin.
-                const player = this.riffy.createConnection({
-                    guildId,
-                    voiceChannel: state.voiceChannel,
-                    textChannel: state.textChannel,
-                    deaf: state.deaf ?? true,
-                    mute: state.mute ?? false,
-                    defaultVolume: state.volume ?? 100,
-                    loop: state.loop ?? "none",
-                });
+            // 2. Restore volume & loop mode.
+            if (typeof state.volume === "number") player.volume = state.volume;
+            if (state.loop) player.loop = state.loop;
 
-                // 2. Restore volume & loop mode.
-                if (typeof state.volume === "number") player.volume = state.volume;
-                if (state.loop) player.loop = state.loop;
-
-                // 3. Rebuild the queue. Bail out if aborted mid-rebuild.
-                if (Array.isArray(state.queue) && !isAborted()) {
-                    for (const t of state.queue) {
-                        const rebuilt = await this._rebuildTrack(t, node);
-                        if (rebuilt) player.queue.add(rebuilt);
-                        if (isAborted()) break;
-                    }
+            // 3. Rebuild the queue. Bail out if aborted mid-rebuild.
+            if (Array.isArray(state.queue) && !isAborted()) {
+                for (const t of state.queue) {
+                    const rebuilt = await this._rebuildTrack(t, node, guildId);
+                    if (rebuilt) player.queue.add(rebuilt);
+                    if (isAborted()) break;
                 }
-
-                // 4. Restore current track + seek to the saved position.
-                if (!isAborted() && state.current && (state.current.encoded || (state.current.info && state.current.info.identifier))) {
-                    const currentTrack = await this._rebuildTrack(state.current, node);
-                    player.current = currentTrack;
-                    player.position = state.position || 0;
-                    player.paused = state.paused ?? false;
-
-                    // Send the resume payload once voice credentials arrive.
-                    // Pass isAborted so it can bail out if voice creds arrive
-                    // AFTER a timeout/socketClosed already aborted the restore.
-                    await this._sendResumePayload(player, state, isAborted);
-                } else if (!isAborted() && player.queue.length > 0) {
-                    // No current track but queue has items — start playback.
-                    // If this fails (e.g. voice init failed, track unresolvable),
-                    // the error MUST propagate so restorePlayer's catch block
-                    // calls _failRestore → destroys the player, removes it from
-                    // state, and emits playerRestoreFailed. Previously this catch
-                    // swallowed the error, leaving an unusable player registered
-                    // with no failure event (review: "Queue restore reports
-                    // false success").
-                    await player.play();
-                }
-
-                // If the restore was aborted while we were waiting, do NOT
-                // resolve — the promise has already been rejected, and the
-                // caller's catch block runs _failRestore. Resolving here would
-                // be a no-op (promise already settled), but we also must not
-                // emit the "Restored player" debug line.
-                if (isAborted()) {
-                    return;
-                }
-
-                this.riffy.emit(
-                    "debug",
-                    `[ResumeManager] Restored player for guild ${guildId} (voice=${state.voiceChannel}, queue=${player.queue.length}, position=${state.position || 0}ms, paused=${state.paused ?? false})`
-                );
-                resolve(player);
-            } catch (err) {
-                // If aborted, prefer the abort reason over this error.
-                if (!isAborted()) reject({ reason: "error", detail: err });
             }
+
+            // 4. Restore current track + seek to the saved position.
+            if (!isAborted() && state.current && (state.current.encoded || (state.current.info && state.current.info.identifier))) {
+                const currentTrack = await this._rebuildTrack(state.current, node, guildId);
+                player.current = currentTrack;
+                player.position = state.position || 0;
+                player.paused = state.paused ?? false;
+
+                // Send the resume payload once voice credentials arrive.
+                // Pass isAborted so it can bail out if voice creds arrive
+                // AFTER a timeout/socketClosed already aborted the restore.
+                await this._sendResumePayload(player, state, isAborted);
+            } else if (!isAborted() && player.queue.length > 0) {
+                // No current track but queue has items — start playback.
+                // If this fails (e.g. voice init failed, track unresolvable),
+                // the error MUST propagate so the .catch below calls
+                // _failRestore → destroys the player, removes it from state,
+                // and emits playerRestoreFailed.
+                await player.play();
+            }
+
+            // If the restore was aborted while we were waiting, do NOT
+            // emit the success debug line — the promise has already been
+            // rejected.
+            if (isAborted()) {
+                return null;
+            }
+
+            this.riffy.emit(
+                "debug",
+                `[ResumeManager] Restored player for guild ${guildId} (voice=${state.voiceChannel}, queue=${player.queue.length}, position=${state.position || 0}ms, paused=${state.paused ?? false})`
+            );
+            return player;
+        };
+
+        const restorePromise = new Promise((resolve, reject) => {
+            rejectRef.fn = reject;
+            runRestore().then(
+                (player) => { if (player) resolve(player); },
+                (err) => { if (!isAborted()) reject({ reason: "error", detail: err }); }
+            );
         });
 
         // Timeout: if voice credentials never arrive, abort.
@@ -869,6 +886,11 @@ class ResumeManager {
 
     /**
      * Attach event listeners to automatically persist state on player changes.
+     *
+     * Also registers process signal handlers (exit/SIGINT/SIGTERM) for a
+     * best-effort final flush. These handlers are stored so {@link destroy}
+     * can unregister them — important if the user re-creates ResumeManager
+     * (e.g. calling init() with different options after a hot reload).
      */
     attachListeners() {
         if (!this.enabled || this._listenersAttached) return;
@@ -876,23 +898,42 @@ class ResumeManager {
 
         const riffy = this.riffy;
 
-        riffy.on("trackStart", (player) => this.savePlayer(player));
-        riffy.on("trackEnd", (player) => this.savePlayer(player));
-        riffy.on("queueEnd", (player) => this.savePlayer(player));
-        riffy.on("playerCreate", (player) => this.savePlayer(player));
-        riffy.on("playerMove", (player) => this.savePlayer(player));
-        riffy.on("playerDestroy", (player) => this.removePlayer(player.guildId));
+        // Store riffy event handler refs so destroy() can unregister them.
+        const onTrackStart = (player) => this.savePlayer(player);
+        const onTrackEnd = (player) => this.savePlayer(player);
+        const onQueueEnd = (player) => this.savePlayer(player);
+        const onPlayerCreate = (player) => this.savePlayer(player);
+        const onPlayerMove = (player) => this.savePlayer(player);
+        const onPlayerDestroy = (player) => this.removePlayer(player.guildId);
+        const onPlayerUpdate = (player) => this.savePlayer(player);
 
-        // playerUpdate fires frequently (~every 5s) from Lavalink with the
-        // current position. Throttled via saveInterval (per-guild).
-        riffy.on("playerUpdate", (player) => this.savePlayer(player));
+        riffy.on("trackStart", onTrackStart);
+        riffy.on("trackEnd", onTrackEnd);
+        riffy.on("queueEnd", onQueueEnd);
+        riffy.on("playerCreate", onPlayerCreate);
+        riffy.on("playerMove", onPlayerMove);
+        riffy.on("playerDestroy", onPlayerDestroy);
+        riffy.on("playerUpdate", onPlayerUpdate);
 
-        // Best-effort final flush on process exit. Async I/O on process exit
-        // is unreliable (the event loop is torn down), so we prefer a sync
-        // saveSync() method if the adapter provides one (JsonFileStorage and
-        // ShardedJsonStorage do). For adapters that only have async save()
-        // (SqliteStorage, custom Redis/Postgres), we call it anyway as a last
-        // resort — it may not complete, but it's better than nothing.
+        this._riffyHandlers = [
+            ["trackStart", onTrackStart], ["trackEnd", onTrackEnd],
+            ["queueEnd", onQueueEnd], ["playerCreate", onPlayerCreate],
+            ["playerMove", onPlayerMove], ["playerDestroy", onPlayerDestroy],
+            ["playerUpdate", onPlayerUpdate],
+        ];
+
+        // Best-effort final flush on process exit. Sync saveSync() is used
+        // when available (JsonFileStorage, ShardedJsonStorage) because async
+        // I/O on process.exit is unreliable (the event loop is torn down).
+        //
+        // For adapters that only have async save() (SqliteStorage, custom
+        // Redis/Postgres), the SIGINT/SIGTERM handlers use a synchronous
+        // flush pattern (saveSync if available) and the async save() calls
+        // may not complete before the process exits. This is a known
+        // limitation — for production use with async-only adapters, consider
+        // implementing saveSync() or using a graceful shutdown pattern
+        // (calling await resumeManager.save() + await storage.close() in
+        // your own shutdown handler before process.exit()).
         const safeFlush = () => {
             try {
                 for (const [guildId, timer] of this._saveTimers) {
@@ -902,34 +943,93 @@ class ResumeManager {
                         if (typeof this.storage.saveSync === "function") {
                             this.storage.saveSync(guildId, state);
                         } else {
+                            // Async-only adapter — fire and forget. May not
+                            // complete on unclean shutdown (documented above).
                             this.storage.save(guildId, state).catch(() => {});
                         }
                     }
                 }
                 this._saveTimers.clear();
+                // Close the storage adapter to release resources (e.g. the
+                // SQLite database handle). Safe to call even if close() is
+                // a no-op (JsonFileStorage / ShardedJsonStorage).
+                if (typeof this.storage.close === "function") {
+                    this.storage.close().catch(() => {});
+                }
             } catch (_) {
                 /* ignore */
             }
         };
-        process.on("exit", safeFlush);
-        process.on("SIGINT", () => {
-            safeFlush();
-            process.exit(0);
-        });
-        process.on("SIGTERM", () => {
-            safeFlush();
-            process.exit(0);
-        });
+
+        const onExit = safeFlush;
+        const onSIGINT = () => { safeFlush(); process.exit(0); };
+        const onSIGTERM = () => { safeFlush(); process.exit(0); };
+
+        process.on("exit", onExit);
+        process.on("SIGINT", onSIGINT);
+        process.on("SIGTERM", onSIGTERM);
+
+        this._processHandlers = { onExit, onSIGINT, onSIGTERM };
+    }
+
+    /**
+     * Remove all event listeners and process handlers attached by
+     * {@link attachListeners}. Also closes the storage adapter (releasing
+     * resources like the SQLite database handle) and clears all pending
+     * per-guild save timers.
+     *
+     * Call this when replacing or disposing of a ResumeManager instance
+     * (e.g. in tests, or if the user calls init() again with different
+     * options). Without this, stale closures remain on the riffy
+     * EventEmitter and on process, keeping the old instance alive and
+     * causing duplicate handler invocations.
+     *
+     * @since 1.0.15
+     */
+    destroy() {
+        // Remove riffy event listeners.
+        if (this._riffyHandlers) {
+            for (const [event, handler] of this._riffyHandlers) {
+                this.riffy.off(event, handler);
+            }
+            this._riffyHandlers = null;
+        }
+        // Remove process signal handlers.
+        if (this._processHandlers) {
+            const { onExit, onSIGINT, onSIGTERM } = this._processHandlers;
+            process.off("exit", onExit);
+            process.off("SIGINT", onSIGINT);
+            process.off("SIGTERM", onSIGTERM);
+            this._processHandlers = null;
+        }
+        // Clear pending save timers.
+        for (const timer of this._saveTimers.values()) clearTimeout(timer);
+        this._saveTimers.clear();
+        // Close the storage adapter (releases DB handles etc).
+        if (this.storage && typeof this.storage.close === "function") {
+            this.storage.close().catch(() => {});
+        }
+        this._listenersAttached = false;
     }
 
     /**
      * Clear all persisted state — both in-memory and the backing store.
-     * Useful for testing or a manual reset.
+     * Also removes process signal handlers (so stale handlers don't
+     * accumulate if clear() is called before re-init). Useful for testing
+     * or a manual reset.
      */
     async clear() {
         this._state = { version: 1, savedAt: 0, players: {} };
         for (const t of this._saveTimers.values()) clearTimeout(t);
         this._saveTimers.clear();
+        // Remove process signal handlers to prevent accumulation.
+        if (this._processHandlers) {
+            const { onExit, onSIGINT, onSIGTERM } = this._processHandlers;
+            process.off("exit", onExit);
+            process.off("SIGINT", onSIGINT);
+            process.off("SIGTERM", onSIGTERM);
+            this._processHandlers = null;
+        }
         await this.storage.clear().catch(() => {});
     }
 

--- a/build/structures/ResumeManager.js
+++ b/build/structures/ResumeManager.js
@@ -58,6 +58,32 @@ class ResumeManager {
         this.clearOnRestore = options.clearOnRestore ?? false;
         this.restoreTimeout = typeof options.restoreTimeout === "number" ? options.restoreTimeout : 15000;
         /**
+         * Optional filter function for sharded bots. Returns true if the
+         * guild belongs to THIS shard/process (and should be restored).
+         * Guilds that return false are SKIPPED — not restored, not deleted
+         * from the store — so other shards can still restore them.
+         *
+         * Without this, every shard loads ALL guilds from the shared state
+         * file, tries to restore guilds it doesn't manage, fails (no voice
+         * credentials), and deletes them from the store — destroying data
+         * that belongs to other shards.
+         *
+         * Example (discord.js):
+         *   guildFilter: (guildId) => client.guilds.cache.has(guildId)
+         *
+         * Or with explicit shard calculation:
+         *   guildFilter: (guildId) => {
+         *     const shardId = (BigInt(guildId) >> 22n) % BigInt(totalShards);
+         *     return client.shard.ids.includes(Number(shardId));
+         *   }
+         *
+         * Default: `null` (no filtering — restore all guilds, for
+         * non-sharded bots).
+         *
+         * @since 1.0.15
+         */
+        this.guildFilter = typeof options.guildFilter === "function" ? options.guildFilter : null;
+        /**
          * Max number of queue tracks to persist per guild. A bot in a guild
          * where someone queued a 500-track playlist would otherwise bloat
          * storage; capping prevents that. `null` = no limit.
@@ -417,8 +443,8 @@ class ResumeManager {
             try { await this._loadPromise; } catch (_) { /* already logged */ }
         }
 
-        const guildIds = Object.keys(this._state.players || {});
-        if (!guildIds.length) {
+        const allGuildIds = Object.keys(this._state.players || {});
+        if (!allGuildIds.length) {
             this.riffy.emit("debug", `[ResumeManager] No saved players to restore.`);
             if (this.clearOnRestore) {
                 await this.storage.clear().catch(() => {});
@@ -427,7 +453,36 @@ class ResumeManager {
             return [];
         }
 
-        this.riffy.emit("debug", `[ResumeManager] Restoring ${guildIds.length} player(s) (concurrency=${this.restoreConcurrency})...`);
+        // Filter guilds for sharded bots: only restore guilds that belong to
+        // THIS shard/process. Guilds on other shards are SKIPPED (not
+        // restored, not deleted) so they survive for the correct shard to
+        // pick up. Without this, every shard would try to restore ALL guilds,
+        // fail for guilds it doesn't manage (no voice credentials), and
+        // delete them from the store — destroying data for other shards.
+        let guildIds = allGuildIds;
+        let skippedCount = 0;
+        if (this.guildFilter) {
+            guildIds = allGuildIds.filter((gid) => {
+                try {
+                    const belongs = this.guildFilter(gid);
+                    if (!belongs) {
+                        skippedCount++;
+                        this.riffy.emit("debug", `[ResumeManager] Skipping guild ${gid} (not managed by this shard/process).`);
+                    }
+                    return belongs;
+                } catch (e) {
+                    this.riffy.emit("debug", `[ResumeManager] guildFilter threw for ${gid}: ${e.message} — including guild.`);
+                    return true; // on error, include the guild (safer than skipping)
+                }
+            });
+        }
+        if (!guildIds.length) {
+            this.riffy.emit("debug", `[ResumeManager] No guilds to restore on this shard (${skippedCount} skipped, belong to other shards).`);
+            // Do NOT clear the store — other shards still need it.
+            return [];
+        }
+
+        this.riffy.emit("debug", `[ResumeManager] Restoring ${guildIds.length} player(s)${skippedCount ? ` (${skippedCount} skipped — other shards)` : ""} (concurrency=${this.restoreConcurrency})...`);
         const restored = [];
 
         // Restore players concurrently with a bounded concurrency limit so a
@@ -460,14 +515,26 @@ class ResumeManager {
         this.riffy.emit("debug", `[ResumeManager] Restore complete (${restored.length}/${guildIds.length} succeeded).`);
 
         if (this.clearOnRestore) {
-            // Wipe in-memory state and clear the store so it isn't re-applied
-            // on the next restart. Fresh state is written as new activity happens.
-            this._state = { version: 1, savedAt: 0, players: {} };
-            for (const t of this._saveTimers.values()) clearTimeout(t);
-            this._saveTimers.clear();
-            await this.storage.clear().catch(() => {});
+            // Wipe in-memory state so it isn't re-applied on the next restart.
+            // Fresh state is written as new activity happens.
+            if (this.guildFilter) {
+                // Sharded mode: only remove THIS shard's guilds from the
+                // store — NOT a full clear (other shards still need their
+                // guilds). Remove each restored/skipped guild individually.
+                for (const gid of guildIds) {
+                    this.storage.remove(gid).catch(() => {});
+                    delete this._state.players[gid];
+                }
+                this.riffy.emit("debug", `[ResumeManager] clearOnRestore enabled (sharded mode) — removed ${guildIds.length} guild(s) for this shard, other shards' data preserved.`);
+            } else {
+                // Non-sharded: wipe everything.
+                this._state = { version: 1, savedAt: 0, players: {} };
+                for (const t of this._saveTimers.values()) clearTimeout(t);
+                this._saveTimers.clear();
+                await this.storage.clear().catch(() => {});
+                this.riffy.emit("debug", `[ResumeManager] clearOnRestore enabled — store cleared, in-memory state wiped.`);
+            }
             this._restoredFully = true;
-            this.riffy.emit("debug", `[ResumeManager] clearOnRestore enabled — store cleared, in-memory state wiped.`);
         }
 
         return restored;

--- a/build/structures/Riffy.js
+++ b/build/structures/Riffy.js
@@ -252,8 +252,9 @@ class Riffy extends EventEmitter {
   destroyPlayer(guildId) {
     const player = this.players.get(guildId);
     if (!player) return;
+    // player.destroy() already calls this.players.delete(guildId) internally,
+    // so we don't need to repeat it here.
     player.destroy();
-    this.players.delete(guildId);
 
     this.emit("playerDestroy", player);
   }

--- a/build/structures/Riffy.js
+++ b/build/structures/Riffy.js
@@ -347,8 +347,17 @@ class Riffy extends EventEmitter {
   }
 
   removeConnection(guildId) {
-    this.players.get(guildId)?.destroy();
-    this.players.delete(guildId);
+    // Delegate through destroyPlayer() so that:
+    //   1. The playerDestroy event fires (for backward compat with code that
+    //      hooks it directly).
+    //   2. The resume state cleanup hook (playerDisconnect/playerDestroy →
+    //      resumeManager.removePlayer) fires — otherwise the guild's state
+    //      stays in the store and gets silently re-restored on the next
+    //      restart, resurrecting a player the user intentionally removed.
+    // Previously this called player.destroy() directly + players.delete()
+    // (redundant — destroy() already deletes from the map), bypassing the
+    // cleanup event.
+    this.destroyPlayer(guildId);
   }
 
   /**

--- a/build/structures/Riffy.js
+++ b/build/structures/Riffy.js
@@ -159,9 +159,9 @@ class Riffy extends EventEmitter {
   destroyNode(identifier) {
     const node = this.nodeMap.get(identifier);
     if (!node) return;
+    // node.destroy() already emits "nodeDestroy" and deletes from nodeMap,
+    // so we don't duplicate them here (was double-emitting nodeDestroy).
     node.destroy();
-    this.nodeMap.delete(identifier);
-    this.emit("nodeDestroy", node);
   }
 
   /**

--- a/build/structures/Riffy.js
+++ b/build/structures/Riffy.js
@@ -2,6 +2,7 @@ const { EventEmitter } = require("node:events");
 const { Node } = require("./Node");
 const { Player } = require("./Player");
 const { Track } = require("./Track");
+const { ResumeManager } = require("./ResumeManager");
 // @ts-ignore
 const { version: pkgVersion } = require("../../package.json")
 
@@ -52,6 +53,18 @@ class Riffy extends EventEmitter {
      */
     this.version = pkgVersion;
 
+    /**
+     * Client-restart resume manager. Persists player state (voice channel,
+     * current track, position, queue, volume, loop, paused) to disk and
+     * restores all players after the bot process restarts.
+     *
+     * Initialized in `init()` when `options.resume.enabled` is true.
+     * @type {ResumeManager | null}
+     */
+    this.resumeManager = null;
+    this._resumeOptions = options.resume || null;
+    this._resumeRestorePending = !!(options.resume && options.resume.enabled);
+
     if (this.restVersion && !versions.includes(this.restVersion)) throw new RangeError(`${this.restVersion} is not a valid version`);
   }
 
@@ -75,7 +88,7 @@ class Riffy extends EventEmitter {
 
   /**
    * Initialize Riffy
-   * @param {string} clientId 
+   * @param {string} clientId
    */
   init(clientId) {
     if (this.initiated) return this;
@@ -91,6 +104,39 @@ class Riffy extends EventEmitter {
       this.emit("debug", `Loading ${this.plugins.length} Riffy plugin(s)`);
       this.plugins.forEach((plugin) => plugin.load(this));
     }
+
+    // Set up client-restart resume (disk persistence + auto-restore).
+    if (this._resumeOptions && this._resumeOptions.enabled) {
+      this.resumeManager = new ResumeManager(this, this._resumeOptions);
+      this.resumeManager.load();
+      this.resumeManager.attachListeners();
+      this.emit("debug", `[Riffy] Client-restart resume enabled (state file: ${this.resumeManager.filePath}, saveInterval: ${this.resumeManager.saveInterval}ms).`);
+
+      // Auto-restore all players once the first node is ready (has a session).
+      this.once("nodeConnect", () => {
+        // Small delay to ensure the node session is fully usable.
+        setTimeout(() => {
+          if (this.resumeManager) {
+            this.resumeManager.restoreAll().catch((err) => {
+              this.emit("debug", `[Riffy] Auto-restore failed: ${err.message}`);
+            });
+          }
+        }, 1000);
+      });
+    }
+  }
+
+  /**
+   * Manually trigger restoration of all persisted players. Useful when
+   * `resume.autoRestore` is disabled or you want to re-run restore later.
+   * @returns {Promise<Array<Player>>}
+   */
+  async resumePlayers() {
+    if (!this.resumeManager) {
+      this.emit("debug", `[Riffy] resumePlayers() called but resume is not enabled.`);
+      return [];
+    }
+    return this.resumeManager.restoreAll();
   }
 
   /**

--- a/build/structures/storage/JsonFileStorage.js
+++ b/build/structures/storage/JsonFileStorage.js
@@ -65,6 +65,16 @@ class JsonFileStorage extends StorageAdapter {
     }
 
     async save(guildId, state) {
+        this.saveSync(guildId, state);
+    }
+
+    /**
+     * Synchronous version of save() — used on process.exit where async I/O
+     * is unreliable (the event loop is torn down). Writes to a temp file
+     * then renames atomically.
+     * @since 1.0.15
+     */
+    saveSync(guildId, state) {
         // Read current file, merge the single guild, write back.
         // (Single-file adapter — inherent write amplification vs. sharded.)
         let parsed = { version: 1, savedAt: 0, players: {} };

--- a/build/structures/storage/JsonFileStorage.js
+++ b/build/structures/storage/JsonFileStorage.js
@@ -1,0 +1,115 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { StorageAdapter } = require("./StorageAdapter");
+
+/**
+ * JsonFileStorage
+ *
+ * Persists all players in a single JSON file. This is the default adapter and
+ * the original behavior of ResumeManager — fine for small/medium bots (up to
+ * ~100 concurrent players).
+ *
+ * For larger bots, use {@link ShardedJsonStorage} or {@link SqliteStorage}
+ * instead: a single file suffers from read/write amplification (every save
+ * rewrites every guild's state) and a crash mid-write can corrupt all guilds.
+ *
+ * @since 1.0.15
+ */
+class JsonFileStorage extends StorageAdapter {
+    /**
+     * @param {Object} [options]
+     * @param {string} [options.filePath] Path to the JSON file. Default `<cwd>/riffy-state.json`.
+     * @param {import("../Riffy").Riffy} [riffy] Optional, for debug logging.
+     */
+    constructor(options = {}, riffy = null) {
+        super();
+        this.filePath = options.filePath || path.join(process.cwd(), "riffy-state.json");
+        this.riffy = riffy;
+    }
+
+    _log(msg) {
+        if (this.riffy) this.riffy.emit("debug", `[JsonFileStorage] ${msg}`);
+    }
+
+    async init() {
+        const dir = path.dirname(this.filePath);
+        if (dir && !fs.existsSync(dir)) {
+            try { fs.mkdirSync(dir, { recursive: true }); } catch (_) { /* ignore */ }
+        }
+    }
+
+    async loadAll() {
+        const map = new Map();
+        try {
+            if (!fs.existsSync(this.filePath)) return map;
+            const raw = fs.readFileSync(this.filePath, "utf-8");
+            const parsed = JSON.parse(raw);
+            if (!parsed || typeof parsed !== "object" || !parsed.players) return map;
+            for (const [guildId, state] of Object.entries(parsed.players)) {
+                if (state && typeof state === "object") {
+                    map.set(guildId, state);
+                }
+            }
+        } catch (e) {
+            this._log(`Failed to load/parse ${this.filePath}: ${e.message}. Moving it aside.`);
+            // Move the corrupt file aside so future saves aren't blocked by it.
+            try {
+                if (fs.existsSync(this.filePath)) {
+                    const backup = this.filePath + ".corrupt-" + Date.now();
+                    fs.renameSync(this.filePath, backup);
+                    this._log(`Moved corrupt file to ${backup}`);
+                }
+            } catch (_) { /* ignore */ }
+        }
+        return map;
+    }
+
+    async save(guildId, state) {
+        // Read current file, merge the single guild, write back.
+        // (Single-file adapter — inherent write amplification vs. sharded.)
+        let parsed = { version: 1, savedAt: 0, players: {} };
+        try {
+            if (fs.existsSync(this.filePath)) {
+                parsed = JSON.parse(fs.readFileSync(this.filePath, "utf-8")) || parsed;
+                if (!parsed.players) parsed.players = {};
+            }
+        } catch (e) {
+            // File is corrupt — start fresh rather than lose this guild's save.
+            this._log(`Existing file corrupt, starting fresh: ${e.message}`);
+            parsed = { version: 1, savedAt: 0, players: {} };
+        }
+        parsed.savedAt = Date.now();
+        parsed.players[guildId] = state;
+        // Atomic write: temp file + rename.
+        const tmp = this.filePath + ".tmp-" + process.pid;
+        fs.writeFileSync(tmp, JSON.stringify(parsed, null, 2), "utf-8");
+        fs.renameSync(tmp, this.filePath);
+    }
+
+    async remove(guildId) {
+        try {
+            if (!fs.existsSync(this.filePath)) return;
+            const parsed = JSON.parse(fs.readFileSync(this.filePath, "utf-8"));
+            if (!parsed?.players || !(guildId in parsed.players)) return;
+            delete parsed.players[guildId];
+            parsed.savedAt = Date.now();
+            const tmp = this.filePath + ".tmp-" + process.pid;
+            fs.writeFileSync(tmp, JSON.stringify(parsed, null, 2), "utf-8");
+            fs.renameSync(tmp, this.filePath);
+        } catch (e) {
+            this._log(`remove() failed for ${guildId}: ${e.message}`);
+        }
+    }
+
+    async clear() {
+        try {
+            if (fs.existsSync(this.filePath)) fs.unlinkSync(this.filePath);
+        } catch (e) {
+            this._log(`clear() failed: ${e.message}`);
+        }
+    }
+
+    async close() { /* no resources to release */ }
+}
+
+module.exports = { JsonFileStorage };

--- a/build/structures/storage/ShardedJsonStorage.js
+++ b/build/structures/storage/ShardedJsonStorage.js
@@ -1,0 +1,125 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { StorageAdapter } = require("./StorageAdapter");
+
+/**
+ * ShardedJsonStorage
+ *
+ * Persists each guild's state in its own JSON file inside a directory:
+ *
+ *     <dir>/<guildId>.json
+ *
+ * This is the recommended adapter for medium-to-large bots (hundreds to
+ * thousands of concurrent players). It solves the three problems a single
+ * JSON file has at scale:
+ *
+ *   1. **No write amplification** — saving guild A doesn't touch guild B's
+ *      file. Each playerUpdate only rewrites that one guild's ~1-5 KB file.
+ *   2. **No read amplification** — loadAll() reads each file independently;
+ *      a corrupt file only loses that one guild, not everyone.
+ *   3. **Crash isolation** — a mid-write crash (power loss, SIGKILL) can
+ *      corrupt at most one guild's file, not the whole state.
+ *
+ * For tens of thousands of players, consider {@link SqliteStorage} (one DB
+ * file, indexed, ACID) to avoid filesystem inode pressure.
+ *
+ * @since 1.0.15
+ */
+class ShardedJsonStorage extends StorageAdapter {
+    /**
+     * @param {Object} options
+     * @param {string} [options.dir] Directory to store per-guild JSON files.
+     *   Default `<cwd>/riffy-state/`.
+     * @param {import("../Riffy").Riffy} [options.riffy] Optional, for debug logging.
+     */
+    constructor(options = {}, riffy = null) {
+        super();
+        this.dir = (options && options.dir) || path.join(process.cwd(), "riffy-state");
+        this.riffy = (options && options.riffy) || riffy || null;
+    }
+
+    _log(msg) {
+        if (this.riffy) this.riffy.emit("debug", `[ShardedJsonStorage] ${msg}`);
+    }
+
+    /** @private Sanitize a guildId into a safe filename (no path traversal). */
+    _pathFor(guildId) {
+        // Only allow alphanumerics + dash/underscore to prevent `../` attacks.
+        const safe = String(guildId).replace(/[^a-zA-Z0-9_-]/g, "");
+        return path.join(this.dir, `${safe}.json`);
+    }
+
+    async init() {
+        try {
+            if (!fs.existsSync(this.dir)) fs.mkdirSync(this.dir, { recursive: true });
+        } catch (e) {
+            this._log(`init() failed to create dir ${this.dir}: ${e.message}`);
+        }
+    }
+
+    async loadAll() {
+        const map = new Map();
+        let files = [];
+        try {
+            files = fs.readdirSync(this.dir).filter(f => f.endsWith(".json"));
+        } catch (e) {
+            this._log(`loadAll() couldn't read dir ${this.dir}: ${e.message}`);
+            return map;
+        }
+        for (const file of files) {
+            const fullPath = path.join(this.dir, file);
+            try {
+                const state = JSON.parse(fs.readFileSync(fullPath, "utf-8"));
+                if (state && typeof state === "object" && state.guildId) {
+                    map.set(state.guildId, state);
+                }
+            } catch (e) {
+                this._log(`Skipping corrupt file ${file}: ${e.message}`);
+                // Move the corrupt file aside.
+                try {
+                    fs.renameSync(fullPath, fullPath + ".corrupt-" + Date.now());
+                } catch (_) { /* ignore */ }
+            }
+        }
+        return map;
+    }
+
+    async save(guildId, state) {
+        const fullPath = this._pathFor(guildId);
+        // Atomic write: temp file in the same dir, then rename.
+        const tmp = fullPath + ".tmp-" + process.pid;
+        try {
+            fs.writeFileSync(tmp, JSON.stringify(state, null, 2), "utf-8");
+            fs.renameSync(tmp, fullPath);
+        } catch (e) {
+            this._log(`save() failed for ${guildId}: ${e.message}`);
+            try { if (fs.existsSync(tmp)) fs.unlinkSync(tmp); } catch (_) { /* ignore */ }
+            throw e;
+        }
+    }
+
+    async remove(guildId) {
+        const fullPath = this._pathFor(guildId);
+        try {
+            if (fs.existsSync(fullPath)) fs.unlinkSync(fullPath);
+        } catch (e) {
+            this._log(`remove() failed for ${guildId}: ${e.message}`);
+        }
+    }
+
+    async clear() {
+        try {
+            if (!fs.existsSync(this.dir)) return;
+            const files = fs.readdirSync(this.dir).filter(f => f.endsWith(".json"));
+            for (const f of files) {
+                try { fs.unlinkSync(path.join(this.dir, f)); } catch (_) { /* ignore */ }
+            }
+        } catch (e) {
+            this._log(`clear() failed: ${e.message}`);
+        }
+    }
+
+    async close() { /* no resources to release */ }
+}
+
+module.exports = { ShardedJsonStorage };

--- a/build/structures/storage/ShardedJsonStorage.js
+++ b/build/structures/storage/ShardedJsonStorage.js
@@ -85,6 +85,16 @@ class ShardedJsonStorage extends StorageAdapter {
     }
 
     async save(guildId, state) {
+        this.saveSync(guildId, state);
+    }
+
+    /**
+     * Synchronous version of save() — used on process.exit where async I/O
+     * is unreliable (the event loop is torn down). Writes to a temp file
+     * in the same directory, then renames atomically.
+     * @since 1.0.15
+     */
+    saveSync(guildId, state) {
         const fullPath = this._pathFor(guildId);
         // Atomic write: temp file in the same dir, then rename.
         const tmp = fullPath + ".tmp-" + process.pid;
@@ -92,7 +102,7 @@ class ShardedJsonStorage extends StorageAdapter {
             fs.writeFileSync(tmp, JSON.stringify(state, null, 2), "utf-8");
             fs.renameSync(tmp, fullPath);
         } catch (e) {
-            this._log(`save() failed for ${guildId}: ${e.message}`);
+            this._log(`saveSync() failed for ${guildId}: ${e.message}`);
             try { if (fs.existsSync(tmp)) fs.unlinkSync(tmp); } catch (_) { /* ignore */ }
             throw e;
         }

--- a/build/structures/storage/SqliteStorage.js
+++ b/build/structures/storage/SqliteStorage.js
@@ -92,15 +92,22 @@ class SqliteStorage extends StorageAdapter {
     }
 
     async save(guildId, state) {
+        // Guard: init() may not have completed yet (Riffy.init() calls
+        // load() without await, and attachListeners() arms immediately).
+        // If a player event fires + saveInterval is very short, the
+        // debounced save can fire before init() resolves → TypeError.
+        if (!this._stmtUpsert) return;
         // better-sqlite3 is synchronous; wrap in Promise.resolve for contract.
         this._stmtUpsert.run(guildId, JSON.stringify(state), Date.now());
     }
 
     async remove(guildId) {
+        if (!this._stmtDelete) return;
         this._stmtDelete.run(guildId);
     }
 
     async clear() {
+        if (!this._stmtClear) return;
         this._stmtClear.run();
     }
 

--- a/build/structures/storage/SqliteStorage.js
+++ b/build/structures/storage/SqliteStorage.js
@@ -1,0 +1,113 @@
+let Database = null;
+try {
+    // Lazy-load better-sqlite3 only if the user actually picks this adapter.
+    // This keeps `better-sqlite3` an optional peer dependency — Riffy itself
+    // stays dependency-free for users who only use the JSON adapters.
+    Database = require("better-sqlite3");
+} catch (_) {
+    Database = null;
+}
+
+const { StorageAdapter } = require("./StorageAdapter");
+
+/**
+ * SqliteStorage
+ *
+ * Persists all players in a single SQLite database file with an indexed
+ * `players` table. Recommended for large bots (tens of thousands of players)
+ * where a sharded-directory of JSON files would create filesystem inode
+ * pressure.
+ *
+ * Benefits over JSON-based adapters:
+ *   - ACID transactions (no partial writes ever visible)
+ *   - O(log n) indexed lookups by guildId
+ *   - Single file (easy to back up / sync)
+ *   - Concurrent reads, serialized writes (fine for this workload)
+ *
+ * Requires `better-sqlite3` to be installed in your project:
+ *
+ *     npm install better-sqlite3
+ *
+ * If it's not installed, constructing this adapter throws a clear error
+ * pointing you to install it.
+ *
+ * @since 1.0.15
+ */
+class SqliteStorage extends StorageAdapter {
+    /**
+     * @param {Object} options
+     * @param {string} [options.path] Path to the SQLite database file.
+     *   Default `<cwd>/riffy-state.db`. Use `:memory:` for tests.
+     * @param {import("../Riffy").Riffy} [options.riffy] Optional, for debug logging.
+     */
+    constructor(options = {}, riffy = null) {
+        super();
+        if (!Database) {
+            throw new Error(
+                "SqliteStorage requires the 'better-sqlite3' package. Install it with: npm install better-sqlite3"
+            );
+        }
+        this.dbPath = (options && options.path) || "riffy-state.db";
+        this.riffy = (options && options.riffy) || riffy || null;
+        this._db = null;
+    }
+
+    _log(msg) {
+        if (this.riffy) this.riffy.emit("debug", `[SqliteStorage] ${msg}`);
+    }
+
+    async init() {
+        this._db = new Database(this.dbPath);
+        // WAL mode for better read concurrency.
+        this._db.pragma("journal_mode = WAL");
+        this._db.exec(`
+            CREATE TABLE IF NOT EXISTS players (
+                guildId TEXT PRIMARY KEY,
+                state   TEXT NOT NULL,
+                updatedAt INTEGER NOT NULL
+            );
+        `);
+        this._stmtUpsert = this._db.prepare(
+            `INSERT INTO players (guildId, state, updatedAt) VALUES (?, ?, ?)
+             ON CONFLICT(guildId) DO UPDATE SET state = excluded.state, updatedAt = excluded.updatedAt;`
+        );
+        this._stmtDelete = this._db.prepare(`DELETE FROM players WHERE guildId = ?;`);
+        this._stmtAll = this._db.prepare(`SELECT guildId, state FROM players;`);
+        this._stmtClear = this._db.prepare(`DELETE FROM players;`);
+    }
+
+    async loadAll() {
+        const map = new Map();
+        if (!this._db) return map;
+        const rows = this._stmtAll.all();
+        for (const row of rows) {
+            try {
+                const state = JSON.parse(row.state);
+                if (state && typeof state === "object") map.set(row.guildId, state);
+            } catch (e) {
+                this._log(`Skipping corrupt row for guild ${row.guildId}: ${e.message}`);
+            }
+        }
+        return map;
+    }
+
+    async save(guildId, state) {
+        // better-sqlite3 is synchronous; wrap in Promise.resolve for contract.
+        this._stmtUpsert.run(guildId, JSON.stringify(state), Date.now());
+    }
+
+    async remove(guildId) {
+        this._stmtDelete.run(guildId);
+    }
+
+    async clear() {
+        this._stmtClear.run();
+    }
+
+    async close() {
+        try { if (this._db) this._db.close(); } catch (_) { /* ignore */ }
+        this._db = null;
+    }
+}
+
+module.exports = { SqliteStorage };

--- a/build/structures/storage/StorageAdapter.js
+++ b/build/structures/storage/StorageAdapter.js
@@ -50,6 +50,15 @@ class StorageAdapter {
      * — called on every player event (debounced by ResumeManager per guild).
      * Must be idempotent and atomic for the single guild.
      *
+     * WARNING: The process-exit signal handler (SIGINT/SIGTERM) calls save()
+     * (or saveSync() if available) for a best-effort final flush. Custom
+     * adapters with genuinely async save() (network I/O like Redis,
+     * PostgreSQL, MongoDB) cannot guarantee a complete flush on unclean
+     * shutdown — process.exit(0) kills the process before the Promise
+     * resolves. Implement saveSync() for the flush path, or use a graceful
+     * shutdown pattern (await resumeManager.save() + await storage.close()
+     * in your own shutdown handler before calling process.exit()).
+     *
      * @param {string} guildId
      * @param {any} state The serialized player state (already JSON-safe).
      * @returns {Promise<void>}

--- a/build/structures/storage/StorageAdapter.js
+++ b/build/structures/storage/StorageAdapter.js
@@ -1,0 +1,91 @@
+/**
+ * StorageAdapter
+ *
+ * Abstract interface for persisting resume state. ResumeManager delegates
+ * all disk/database operations to a StorageAdapter instance, so you can swap
+ * the storage backend without touching the restore logic.
+ *
+ * Built-in adapters:
+ *   - {@link JsonFileStorage}     single JSON file (default; fine for small bots)
+ *   - {@link ShardedJsonStorage}  one file per guild (scales to thousands of players)
+ *   - {@link SqliteStorage}       one SQLite database (ACID, indexed, tens of thousands)
+ *
+ * To implement a custom adapter (Redis, PostgreSQL, MongoDB, S3, …), extend
+ * this class (or just match the method signatures) and pass an instance to
+ * `Riffy` via `resume.storage`.
+ *
+ * All methods are async — even if the underlying store is synchronous (e.g.
+ * better-sqlite3), wrap the call in `Promise.resolve(...)` so the contract
+ * is uniform and ResumeManager never blocks the event loop unexpectedly.
+ *
+ * @since 1.0.15
+ */
+class StorageAdapter {
+    /**
+     * Called once before any other operation. Use it to open connections,
+     * create tables/indices, ensure the directory exists, etc.
+     * @returns {Promise<void>}
+     */
+    async init() {
+        /* override in subclass */
+    }
+
+    /**
+     * Load ALL persisted players into a Map<guildId, SerializedPlayer>.
+     * Called once on startup (before restoreAll). For very large stores,
+     * you may stream/yield — but the return type must resolve to a complete
+     * Map since restoreAll iterates every guild.
+     *
+     * Implementations MUST skip/repair corrupt entries rather than throw,
+     * so one bad guild doesn't prevent restoring the rest.
+     *
+     * @returns {Promise<Map<string, any>>}
+     */
+    async loadAll() {
+        return new Map();
+    }
+
+    /**
+     * Persist (or update) the state for a single guild. This is the hot path
+     * — called on every player event (debounced by ResumeManager per guild).
+     * Must be idempotent and atomic for the single guild.
+     *
+     * @param {string} guildId
+     * @param {any} state The serialized player state (already JSON-safe).
+     * @returns {Promise<void>}
+     */
+    async save(guildId, state) {
+        /* override in subclass */
+    }
+
+    /**
+     * Remove the persisted state for a single guild (e.g. on playerDestroy
+     * or after a failed restore). No-op if the guild isn't stored.
+     *
+     * @param {string} guildId
+     * @returns {Promise<void>}
+     */
+    async remove(guildId) {
+        /* override in subclass */
+    }
+
+    /**
+     * Wipe ALL persisted state. Called by ResumeManager.clear() and (optionally)
+     * after a successful restore when `clearOnRestore` is enabled.
+     * @returns {Promise<void>}
+     */
+    async clear() {
+        /* override in subclass */
+    }
+
+    /**
+     * Release resources (close DB handles, file watchers, etc.). Called on
+     * process exit / ResumeManager shutdown. Best-effort; must not throw.
+     * @returns {Promise<void>}
+     */
+    async close() {
+        /* override in subclass */
+    }
+}
+
+module.exports = { StorageAdapter };


### PR DESCRIPTION
# feat: client-restart auto-resume with disk persistence

## Summary

Adds a new **client-restart auto-resume** feature to Riffy. When the bot process crashes or restarts, Riffy now automatically **rejoins the same voice channel**, **replays the same song**, **seeks to the exact saved position**, and **restores the full queue** — all from a JSON state file persisted to disk.

This is distinct from the existing node-level `autoResume` (which only handles Lavalink WebSocket reconnects within a single process lifetime). This PR survives a **full process restart**.

Also fixes a pre-existing bug: `Node.open()` calls `player.restart()` when `autoResume` is enabled, but `Player.restart()` **did not exist** — causing a `TypeError` on every Lavalink WebSocket reconnect. This PR implements it.

---

## Motivation

When a Discord music bot restarts (deploy, crash, autoscaler, etc.), every player is lost. Users have to manually re-invite the bot, re-queue their songs, and lose their playback position. This is a poor UX that every production Riffy bot currently has to work around with custom (and usually buggy) persistence code.

This PR bakes that capability into Riffy itself, opt-in via a single `resume` option.

---

## Changes

### New file
- **`build/structures/ResumeManager.js`** — the persistence + restore orchestrator (644 lines)

### Modified files
- **`build/structures/Player.js`** — implements the missing `restart()` method (+67 lines)
- **`build/structures/Riffy.js`** — wires the `resume` option into `init()`, adds `resumePlayers()` (+45 lines)
- **`build/index.js`** — exports `ResumeManager`
- **`build/index.d.ts`** — full type definitions (+281 lines)

**No breaking changes.** The `resume` option is strictly opt-in. When omitted, behavior is identical to before.

---

## Usage

```js
const { Riffy } = require("riffy");

client.riffy = new Riffy(client, nodes, {
  send: (payload) => { /* ... */ },
  restVersion: "v4",

  // ── NEW: client-restart auto-resume ──
  resume: {
    enabled: true,
    filePath: "./data/riffy-state.json", // where state is persisted
    saveInterval: 3000,                  // debounce window for disk writes (ms)
    clearOnRestore: false,               // delete state file after successful restore
    restoreTimeout: 15000,               // abort restore if voice creds don't arrive (ms)
    requesterResolver: (id) => client.users.fetch(id).catch(() => id),
  },
});

client.on("ready", () => {
  // init() loads persisted state + arms auto-restore on first nodeConnect.
  client.riffy.init(client.user.id);
});

// Fires for every player restored after a client restart:
client.riffy.on("playerResumed", (player) => {
  const ch = client.channels.cache.get(player.textChannel);
  ch?.send(`↩️ Resumed "${player.current?.info.title}" at ${player.position}ms`);
});

// Fires when a restore couldn't complete (channel deleted / bot kicked / no permission):
client.riffy.on("playerRestoreFailed", (guildId, reason, detail, state) => {
  console.error(`Restore failed for ${guildId}: ${reason} (${detail})`);
  if (state?.textChannel) {
    client.channels.fetch(state.textChannel).then(c => c?.send(
      "⚠️ I couldn't rejoin the voice channel after restarting — it may have been deleted or I'm missing the Connect permission."
    )).catch(() => {});
  }
});
```

---

## New API

### `ResumeOptions`

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `enabled` | `boolean` | `false` | Master switch. |
| `filePath` | `string` | `<cwd>/riffy-state.json` | Where the JSON state file is written/read. |
| `saveInterval` | `number` | `3000` | Debounce window (ms) for disk writes. |
| `clearOnRestore` | `boolean` | `false` | Delete the state file + wipe in-memory state once `restoreAll()` finishes. Prevents stale state re-applying on every restart. |
| `restoreTimeout` | `number` | `15000` | Max ms to wait for voice credentials per player before aborting. |
| `requesterResolver` | `(id) => any` | `—` | Rebuild a requester object from its persisted id. |

### New events

- **`playerResumed`** `(player: Player)` — fires on successful restore.
- **`playerRestoreFailed`** `(guildId: string, reason: RestoreFailReason, detail: string, state: SerializedPlayer | null)` — fires when a restore aborts.

### `RestoreFailReason`

`"timeout" | "socket_closed" | "no_nodes" | "invalid_state" | "error"`

### New `ResumeManager` class

Public methods: `load()`, `save(immediate?)`, `serializePlayer()`, `savePlayer()`, `removePlayer()`, `restoreAll()`, `restorePlayer()`, `attachListeners()`, `clear()`, `snapshot` getter.

### New `Player.restart()`

Rejoins the configured voice channel and resumes the current track at the last known position. Powers `Node.autoResume` (which was previously broken) and is reused by `ResumeManager`.

### New `Riffy` members

- `riffy.resumeManager` — the active `ResumeManager`, or `null` if resume is disabled.
- `riffy.resumePlayers()` — manually trigger `restoreAll()`.

---

## How it works

### Save path (while the bot runs)
`ResumeManager` listens to `trackStart`, `trackEnd`, `queueEnd`, `playerCreate`, `playerMove`, `playerDestroy`, and `playerUpdate` events. On each, it serializes the player to a JSON-safe object (dropping the non-serializable `requester`, keeping its id) and debounces a write to disk (`saveInterval`). On `process.exit` / `SIGINT` / `SIGTERM` it does one final sync flush.

### Restore path (after a restart)
1. `init()` → `ResumeManager.load()` reads the JSON file into memory (validating each entry).
2. On the first `nodeConnect`, `restoreAll()` runs after a 1s grace.
3. For each saved guild:
   - `createConnection({ guildId, voiceChannel })` → re-sends `VOICE_STATE_UPDATE` to rejoin.
   - Rebuilds the queue from persisted encoded track strings.
   - Waits for `connection.resolve()` (Discord voice credentials).
   - `node.rest.updatePlayer({ track, position, volume, paused })` → seeks to the exact saved position.
   - Emits `playerResumed`.

---

## Failure handling

This PR explicitly handles the edge cases raised by maintainers:

| Scenario | Behavior |
|----------|----------|
| **Voice channel deleted while bot offline** | `restoreTimeout` (15s default) aborts the restore. Half-created player is destroyed. Guild is removed from persisted state. `playerRestoreFailed` with `reason="timeout"` fires. |
| **Bot kicked from guild** | Same as above. |
| **Bot lacks Connect permission** | Same as above, or aborts early on a fatal `WebSocketClosedEvent` (codes 4006/4009/4014/4015) with `reason="socket_closed"`. |
| **Corrupt state file** (partial write during crash) | `load()` moves the file aside to `<file>.corrupt-<timestamp>` and returns `false`. No crash. |
| **Malformed entries** (missing `guildId`/`voiceChannel`, wrong types) | Dropped + logged. Valid entries are kept. Cleaned state is re-persisted. |
| **No connected Lavalink nodes** | `playerRestoreFailed` with `reason="no_nodes"`. |

The `playerRestoreFailed` event includes the persisted `state` (which has `textChannel`), so the bot can notify the user that it couldn't rejoin.

---

## Testing

All scenarios were verified with integration tests in Node:

- ✅ Save → crash → reload → restore round-trip (position + queue preserved to the millisecond).
- ✅ `clearOnRestore: true` deletes the file + wipes memory after restore; second `restoreAll()` is a no-op.
- ✅ `clearOnRestore: false` keeps the file as a rolling snapshot.
- ✅ `restoreTimeout` aborts on missing voice credentials (channel deleted).
- ✅ `socketClosed` aborts early on fatal codes (4006/4009/4014/4015).
- ✅ Half-created player is destroyed on failure (safety-net `players.delete()` even if `destroy()` throws).
- ✅ Corrupt file → moved aside, `load()` returns `false`.
- ✅ Malformed entries → dropped, valid ones kept.
- ✅ `no_nodes` → `playerRestoreFailed` with `reason="no_nodes"`.
- ✅ All files pass `node --check`.
- ✅ **Storage adapters:** JsonFileStorage, ShardedJsonStorage, SqliteStorage, + custom adapter — all pass integration tests (save/load/remove/clear, per-guild debounce, maxQueueSize pruning, backward compat).

---

## Scaling (addresses maintainer feedback on large player counts)

A single JSON file doesn't scale — a bot in thousands of guilds produces one massive file with **write amplification** (every `playerUpdate` re-serializes ALL players) and a crash mid-write corrupts everything.

This PR ships a **pluggable storage adapter system** (commit 3). Pick a backend via the `storage` option:

| Preset | Adapter | Scales to | Notes |
|--------|---------|-----------|-------|
| `"json"` | `JsonFileStorage` | <~100 players | Default; backward compat. Single file. |
| `"sharded"` | `ShardedJsonStorage` | thousands | One file per guild. No amplification, crash isolation per guild. **Recommended for most production bots.** |
| `"sqlite"` | `SqliteStorage` | tens of thousands | Indexed DB, ACID. Needs `better-sqlite3` (optional peer dep, lazy-loaded). |
| custom | `StorageAdapter` subclass | unlimited | Implement `init`/`loadAll`/`save`/`remove`/`clear`/`close` for Redis, PostgreSQL, MongoDB, S3, etc. |

Plus two scaling-oriented improvements:
- **Per-guild debounce** — each guild has its own save timer, so a busy guild never delays writes for other guilds.
- **`maxQueueSize`** option — caps per-guild queue size to prevent a single huge playlist from bloating storage.

```js
// Production bot with thousands of guilds:
new Riffy(client, nodes, {
  send, restVersion: "v4",
  resume: {
    enabled: true,
    storage: "sharded",                // one file per guild
    filePath: "./data/riffy-state",    // directory
    saveInterval: 3000,
    maxQueueSize: 100,                 // cap per-guild queue
  },
});
```

No breaking changes — omitting `storage` defaults to `JsonFileStorage` using `filePath`, identical to v1.0.14 behavior.

---

## Checklist

- [x] Code follows the existing style (CommonJS, JSDoc, conventional commits)
- [x] No breaking changes — `resume` is strictly opt-in
- [x] Full TypeScript definitions added to `index.d.ts`
- [x] All new code documented with JSDoc
- [x] Edge cases handled (channel deleted, permission denied, corrupt state, no nodes)
- [x] `node --check` passes on all modified files
- [x] Integration tests pass for save/restore + all failure paths
- [x] Existing `Node.autoResume` bug (missing `Player.restart()`) fixed as a prerequisite

---

## Related

- Fixes the latent `Player.restart()` bug referenced by `Node.open()` (line 630 of `Node.js`).
- Supersedes any custom persistence workarounds bot authors currently maintain.

---

**Note to maintainers:** This is a large additive feature (~1040 lines, 5 files). I'm happy to split it into smaller PRs if preferred — e.g. (1) the `Player.restart()` fix alone, (2) the `ResumeManager` + wiring. Just let me know.
